### PR TITLE
fix: load .env from $VAULT_ROOT first (single source of truth)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,19 @@
 # ============================================================
 # knowledge-wiki — Konfiguration
-# Kopiere diese Datei nach .env und fülle die Werte aus.
-# .env ist in .gitignore und wird NIE eingecheckt.
+#
+# Kanonische .env liegt im Vault ($VAULT_ROOT/.env) — wird via OneDrive
+# zwischen Maschinen synchronisiert (single source of truth, zusammen mit
+# watchers.json und code-repos.yaml).
+#
+# Skripte laden in dieser Reihenfolge (höhere Prio überschreibt nicht):
+#   1. OS-Umgebungsvariablen (setx VAULT_ROOT ...)
+#   2. $VAULT_ROOT/.env       — Vault-zentrale Credentials
+#   3. <repo>/.env            — Optional, lokale Overrides pro Maschine
+#
+# Voraussetzung: VAULT_ROOT als Windows User-Env gesetzt
+#   setx VAULT_ROOT "C:\Users\<user>\OneDrive - INFORM GmbH\knowledge-wiki"
+#
+# Falls VAULT_ROOT nicht gesetzt ist, wird nur die lokale .env gelesen.
 # ============================================================
 
 # Azure OpenAI — Ressource anlegen unter: https://portal.azure.com

--- a/code-extract.py
+++ b/code-extract.py
@@ -30,7 +30,11 @@ sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding="utf-8", errors="repla
 
 try:
     from dotenv import load_dotenv
-    load_dotenv(Path(__file__).parent / ".env")
+    # Order: OS env > Vault .env (kanonisch, OneDrive-synced) > Script-local .env (Fallback)
+    _vault = os.environ.get("VAULT_ROOT")
+    if _vault:
+        load_dotenv(Path(_vault) / ".env", override=False)
+    load_dotenv(Path(__file__).parent / ".env", override=False)
 except ImportError:
     pass
 

--- a/code-ingest.py
+++ b/code-ingest.py
@@ -34,7 +34,11 @@ sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding="utf-8", errors="repla
 
 try:
     from dotenv import load_dotenv
-    load_dotenv(Path(__file__).parent / ".env")
+    # Order: OS env > Vault .env (kanonisch, OneDrive-synced) > Script-local .env (Fallback)
+    _vault = os.environ.get("VAULT_ROOT")
+    if _vault:
+        load_dotenv(Path(_vault) / ".env", override=False)
+    load_dotenv(Path(__file__).parent / ".env", override=False)
 except ImportError:
     pass
 

--- a/code-watch.py
+++ b/code-watch.py
@@ -35,7 +35,11 @@ sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding="utf-8", errors="repla
 
 try:
     from dotenv import load_dotenv
-    load_dotenv(Path(__file__).parent / ".env")
+    # Order: OS env > Vault .env (kanonisch, OneDrive-synced) > Script-local .env (Fallback)
+    _vault = os.environ.get("VAULT_ROOT")
+    if _vault:
+        load_dotenv(Path(_vault) / ".env", override=False)
+    load_dotenv(Path(__file__).parent / ".env", override=False)
 except ImportError:
     pass
 

--- a/extract-images.py
+++ b/extract-images.py
@@ -31,7 +31,11 @@ sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding="utf-8", errors="repla
 # .env laden falls vorhanden
 try:
     from dotenv import load_dotenv
-    load_dotenv(Path(__file__).parent / ".env")
+    # Order: OS env > Vault .env (kanonisch, OneDrive-synced) > Script-local .env (Fallback)
+    _vault = os.environ.get("VAULT_ROOT")
+    if _vault:
+        load_dotenv(Path(_vault) / ".env", override=False)
+    load_dotenv(Path(__file__).parent / ".env", override=False)
 except ImportError:
     pass
 

--- a/extract.py
+++ b/extract.py
@@ -26,7 +26,11 @@ sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding="utf-8", errors="repla
 # .env laden falls vorhanden
 try:
     from dotenv import load_dotenv
-    load_dotenv(Path(__file__).parent / ".env")
+    # Order: OS env > Vault .env (kanonisch, OneDrive-synced) > Script-local .env (Fallback)
+    _vault = os.environ.get("VAULT_ROOT")
+    if _vault:
+        load_dotenv(Path(_vault) / ".env", override=False)
+    load_dotenv(Path(__file__).parent / ".env", override=False)
 except ImportError:
     pass
 

--- a/generate.py
+++ b/generate.py
@@ -12,6 +12,7 @@ Usage:
 Default-Template: templates/inform-master-de.potx
 """
 
+import os
 import sys
 import io
 import json
@@ -28,7 +29,11 @@ sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding="utf-8", errors="repla
 # .env laden falls vorhanden
 try:
     from dotenv import load_dotenv
-    load_dotenv(Path(__file__).parent / ".env")
+    # Order: OS env > Vault .env (kanonisch, OneDrive-synced) > Script-local .env (Fallback)
+    _vault = os.environ.get("VAULT_ROOT")
+    if _vault:
+        load_dotenv(Path(_vault) / ".env", override=False)
+    load_dotenv(Path(__file__).parent / ".env", override=False)
 except ImportError:
     pass
 

--- a/ingest.py
+++ b/ingest.py
@@ -24,7 +24,11 @@ from pydantic import BaseModel
 # .env laden falls vorhanden
 try:
     from dotenv import load_dotenv
-    load_dotenv(Path(__file__).parent / ".env")
+    # Order: OS env > Vault .env (kanonisch, OneDrive-synced) > Script-local .env (Fallback)
+    _vault = os.environ.get("VAULT_ROOT")
+    if _vault:
+        load_dotenv(Path(_vault) / ".env", override=False)
+    load_dotenv(Path(__file__).parent / ".env", override=False)
 except ImportError:
     pass
 

--- a/manual-ingest.py
+++ b/manual-ingest.py
@@ -39,7 +39,11 @@ sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding="utf-8", errors="repla
 
 try:
     from dotenv import load_dotenv
-    load_dotenv(Path(__file__).parent / ".env")
+    # Order: OS env > Vault .env (kanonisch, OneDrive-synced) > Script-local .env (Fallback)
+    _vault = os.environ.get("VAULT_ROOT")
+    if _vault:
+        load_dotenv(Path(_vault) / ".env", override=False)
+    load_dotenv(Path(__file__).parent / ".env", override=False)
 except ImportError:
     pass
 

--- a/pm-synthesize.py
+++ b/pm-synthesize.py
@@ -31,7 +31,11 @@ sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding="utf-8", errors="repla
 
 try:
     from dotenv import load_dotenv
-    load_dotenv(Path(__file__).parent / ".env")
+    # Order: OS env > Vault .env (kanonisch, OneDrive-synced) > Script-local .env (Fallback)
+    _vault = os.environ.get("VAULT_ROOT")
+    if _vault:
+        load_dotenv(Path(_vault) / ".env", override=False)
+    load_dotenv(Path(__file__).parent / ".env", override=False)
 except ImportError:
     pass
 

--- a/rebuild-code-wiki-index.py
+++ b/rebuild-code-wiki-index.py
@@ -32,7 +32,11 @@ sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding="utf-8", errors="repla
 
 try:
     from dotenv import load_dotenv
-    load_dotenv(Path(__file__).parent / ".env")
+    # Order: OS env > Vault .env (kanonisch, OneDrive-synced) > Script-local .env (Fallback)
+    _vault = os.environ.get("VAULT_ROOT")
+    if _vault:
+        load_dotenv(Path(_vault) / ".env", override=False)
+    load_dotenv(Path(__file__).parent / ".env", override=False)
 except ImportError:
     pass
 

--- a/synthesize.py
+++ b/synthesize.py
@@ -38,7 +38,11 @@ from pydantic import BaseModel
 # .env laden falls vorhanden — gleiche Konvention wie ingest.py
 try:
     from dotenv import load_dotenv
-    load_dotenv(Path(__file__).parent / ".env")
+    # Order: OS env > Vault .env (kanonisch, OneDrive-synced) > Script-local .env (Fallback)
+    _vault = os.environ.get("VAULT_ROOT")
+    if _vault:
+        load_dotenv(Path(_vault) / ".env", override=False)
+    load_dotenv(Path(__file__).parent / ".env", override=False)
 except ImportError:
     pass
 

--- a/test-connection.py
+++ b/test-connection.py
@@ -6,7 +6,11 @@ import os, sys
 from pathlib import Path
 try:
     from dotenv import load_dotenv
-    load_dotenv(Path(__file__).parent / ".env")
+    # Order: OS env > Vault .env (kanonisch, OneDrive-synced) > Script-local .env (Fallback)
+    _vault = os.environ.get("VAULT_ROOT")
+    if _vault:
+        load_dotenv(Path(_vault) / ".env", override=False)
+    load_dotenv(Path(__file__).parent / ".env", override=False)
 except ImportError:
     pass
 

--- a/wiki-sync.py
+++ b/wiki-sync.py
@@ -32,7 +32,11 @@ from datetime import datetime, timezone
 
 try:
     from dotenv import load_dotenv
-    load_dotenv(Path(__file__).parent / ".env")
+    # Order: OS env > Vault .env (kanonisch, OneDrive-synced) > Script-local .env (Fallback)
+    _vault = os.environ.get("VAULT_ROOT")
+    if _vault:
+        load_dotenv(Path(_vault) / ".env", override=False)
+    load_dotenv(Path(__file__).parent / ".env", override=False)
 except ImportError:
     pass
 


### PR DESCRIPTION
## Problem

Nach dem Subtree-Merge (#24) lasen die 13 Python-Skripte weiterhin nur eine `.env` neben sich selbst. Die kanonische `.env` liegt aber im Vault (OneDrive-synced zwischen Maschinen) — wie `watchers.json` und `code-repos.yaml`. Inkonsistent, und nach dem Löschen von `C:\Code\knowledge-tree` waren die Pipelines im aktiven Code-Verzeichnis ohne Credentials.

## Fix

Einheitliche Load-Order in allen 13 Skripten mit `load_dotenv()`:

1. **OS-Env** (`setx VAULT_ROOT ...`) — höchste Priorität
2. **\$VAULT_ROOT/.env** (kanonisch, Vault-zentral, OneDrive-synced)
3. **\<repo\>/.env** (Override pro Maschine, optional)

\`override=False\` auf beiden \`load_dotenv\`-Aufrufen erzwingt die Reihenfolge — kein Wert wird überschrieben, sobald er einmal aus höherer Priorität kommt.

\`\`\`python
try:
    from dotenv import load_dotenv
    # Order: OS env > Vault .env (kanonisch, OneDrive-synced) > Script-local .env (Fallback)
    _vault = os.environ.get(\"VAULT_ROOT\")
    if _vault:
        load_dotenv(Path(_vault) / \".env\", override=False)
    load_dotenv(Path(__file__).parent / \".env\", override=False)
except ImportError:
    pass
\`\`\`

## Verhalten

| VAULT_ROOT gesetzt | Vault-.env existiert | Lokales .env | Ergebnis |
|---|---|---|---|
| ✓ | ✓ | – | **Vault gewinnt** |
| ✓ | – | ✓ | Lokal (Fallback) |
| ✓ | ✓ | ✓ | Vault gewinnt für Keys die er hat, Lokal fängt den Rest |
| – | (n/a) | ✓ | Lokal (= bisheriges Verhalten) |
| – | (n/a) | – | Kein .env geladen — wie bisher |

Vollständig rückwärtskompatibel: ohne `VAULT_ROOT` ändert sich nichts.

## Smoke-Test

\`\`\`powershell
setx VAULT_ROOT \"C:\Users\<user>\OneDrive - INFORM GmbH\knowledge-wiki\"
# (neuer Shell)
uv run test-connection.py
# → OK � gpt-5.3-chat antwortet: OK
\`\`\`

## Sonstiges

- \`generate.py\`: \`import os\` ergänzt — fehlte, der \`dotenv\`-Block war toter Codepfad.
- \`.env.example\`: erklärt Load-Order + Setup-Kommando am Anfang.
- \`transcript-ingest.py\` braucht keinen Patch — delegiert an \`ingest.py\`, lädt selbst keine env.

## Test plan

- [ ] \`setx VAULT_ROOT \"...\"\` einmalig setzen (oder verifizieren dass es schon gesetzt ist)
- [ ] \`uv run test-connection.py\` → OK
- [ ] \`uv run code-watch.py\` → liest \`\$VAULT_ROOT/code-repos.yaml\`, kein Crash
- [ ] \`watch.ps1\` als at_logon-Watcher startet weiter (PowerShell-Watcher erbt User-Env automatisch)
- [ ] Falls jemand lokales \`.env\` neben einem Skript anlegt: dieses wirkt als Override für nicht-vault-definierte Keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)