### PR TITLE
Add clippings-ingest pipeline for Obsidian Web Clipper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ _personal-*/
 # Rohdokumente (grosse Binärdateien — nicht in Git)
 raw/
 
+# Obsidian-Web-Clipper-Ablage (Vault-Inhalt, OneDrive-Sync reicht)
+Clippings/
+
 # Wiki-Vault (generierter Inhalt — OneDrive-Sync reicht)
 wiki/
 
@@ -27,6 +30,7 @@ vault-tree.yaml
 
 # Watch-State
 .code-watch-state.json
+.clippings-state.json
 *.lock
 
 # Windows

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,9 @@ raw/                   # Unveränderliche Quellen — NUR LESEN, niemals modifiz
   manuals/             # PDF-Handbücher (eigene Pipeline: manual-ingest.py)
   .cache/              # Intern: extrahierte Texte + Bilder (nicht anfassen)
 
+Clippings/             # Obsidian-Web-Clipper-Ablage (.md) — eigene Pipeline: clippings-ingest.py
+                       #   liegt im Vault-Root (Obsidian-Default), NICHT unter raw/
+
 wiki/                  # Alles hier wird von Dir gepflegt
   index.md             # Inhaltsverzeichnis aller Wiki-Seiten
   log.md               # Append-only Aktivitätslog
@@ -94,6 +97,19 @@ uv run transcript-ingest.py raw/transcripts/foo.docx --no-ingest   # Nur Cache, 
 **Wo finde ich das Teams-Transkript?**
 Nicht lokal — in der Cloud. Teams öffnen → Kalender → Meeting → **Recap** → **Transkript** → **Herunterladen** als `.docx`. Datei dann nach `raw/transcripts/` legen und `transcript-ingest.py` aufrufen.
 
+### clippings-ingest.py — Obsidian-Web-Clipper-Clips (eigene Pipeline)
+```bash
+uv run clippings-ingest.py              # Single-Poll: neue/geänderte Clips ingesten
+uv run clippings-ingest.py --force      # alle Clips erneut ingesten
+uv run clippings-ingest.py --dry-run    # nur anzeigen, kein LLM-Aufruf
+uv run clippings-ingest.py --clippings-dir <pfad>   # abweichender Ordner
+```
+- Der **Obsidian Web Clipper** speichert geclippte Web-Seiten als `.md` im Vault-Ordner `Clippings/` — **außerhalb von `raw/`**, daher sieht `watch.ps1` sie nicht. Diese Pipeline schließt die Lücke.
+- Scannt `Clippings/**/*.md` und ruft für jede neue/geänderte Datei den regulären `ingest.py`-Flow auf — fachlich wie eine `raw/links`-Quelle (Web-Artikel → Quellenübersicht + Konzepte + `index.md`/`log.md`).
+- Eigener State (`path → mtime`) in `.clippings-state.json`, weil `ingest.py` für `.md`-Inputs keinen `raw/.cache`-Eintrag schreibt (Dedup wie bei `scan-raw.py`).
+- Läuft als Scheduled Task `WikiClippings` (Single-Poll alle 15 Min, siehe `watchers.json`). `cwd` defaultet auf den Repo-Root, daher keine Pfad-Argumente nötig.
+- **Alternativ** kann man den Web-Clipper-Zielordner direkt auf `raw/links/` umstellen — dann übernimmt der reguläre Watcher. Default-Clippings + diese Pipeline ist aber der wartungsärmere Weg (kein Obsidian-Reconfig).
+
 ### manual-ingest.py — PDF-Handbücher
 ```bash
 uv run manual-ingest.py raw/manuals/Handbuch.pdf --product produkt-slug --max-level 2
@@ -119,6 +135,7 @@ uv run code-watch.py --loop     # Daemon-Modus (nur für Debugging)
 
 | Skript | Zweck |
 |--------|-------|
+| `clippings-ingest.py` | Obsidian-Web-Clipper-Clips (`Clippings/*.md`) → regulärer `ingest.py`-Flow |
 | `code-extract.py` | GitHub-Commit-Diff → CommitDigest-JSON |
 | `code-ingest.py` | CommitDigest → `wiki/code-wiki/<projekt>/` |
 | `extract-images.py` | Batch-Vision für Bilder aus PPTX/PDF |

--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -7,16 +7,19 @@ anpasst, muss hier nachsehen — und das Dokument bei Änderungen aktualisieren.
 
 ## Übersicht
 
-In pkwiki gibt es **drei** Ingest-Pipelines mit unterschiedlichen Triggern:
+In pkwiki gibt es **vier** Ingest-Pipelines mit unterschiedlichen Triggern:
 
 | Pipeline | Eingangsformat | Drop-Ordner | Wer triggert |
 |---|---|---|---|
 | `ingest.py` (regulär) | .pdf / .pptx / .docx / .txt | `raw/pdfs/`, `raw/slides/`, `raw/docs/`, `raw/links/` | `watch.ps1` (lokaler PowerShell-Watcher in pkwiki) |
 | `manual-ingest.py` | .pdf | `raw/manuals/` | `code-watch.py` (knowledge-tree) |
 | `transcript-ingest.py` | .docx | `raw/transcripts/` | `code-watch.py` (knowledge-tree) |
+| `clippings-ingest.py` | .md | `Clippings/` (Vault-Root, **nicht** unter `raw/`) | lokaler Scheduled Task `WikiClippings` (`watchers.json`) |
 
 `raw/manuals/` und `raw/transcripts/` werden von `watch.ps1` **bewusst ignoriert**
-— sie sind extern getriggert.
+— sie sind extern getriggert. Der `Clippings/`-Ordner liegt außerhalb von `raw/`
+und wird daher von `watch.ps1` ebenfalls nicht gesehen; ihn deckt der lokale
+Scheduled Task `WikiClippings` ab (kein externer Watcher nötig).
 
 ## Trigger-Bedingung (für externe Watcher)
 

--- a/README.md
+++ b/README.md
@@ -409,6 +409,8 @@ raw/               # Rohdokumente — hierhin neue Dateien ablegen
   inbox/           # Temporärer Eingang
   .cache/          # Auto-generierte Extrakte (nicht in Git)
 
+Clippings/         # Obsidian-Web-Clipper-Ablage (.md) — Pipeline: clippings-ingest.py
+
 wiki/              # Die Wissensbasis — nur lokal + OneDrive-Sync
   index.md         # Inhaltsverzeichnis aller Seiten
   log.md           # Append-only Aktivitätslog
@@ -420,6 +422,7 @@ wiki/              # Die Wissensbasis — nur lokal + OneDrive-Sync
 ingest.py          # Haupt-Pipeline: Dokument → Wiki-Seiten
 extract.py         # Extraktion: PPTX/DOCX/PDF → Markdown + Vision
 watch.ps1          # Watcher: neue Dateien in raw/ → automatischer Ingest
+clippings-ingest.py # Pipeline: Obsidian-Web-Clipper-Clips (Clippings/*.md) → Wiki
 CLAUDE.md          # Schema & Regeln für den LLM-Maintainer
 .env.example       # Vorlage fur Azure-Credentials
 ```

--- a/clippings-ingest.py
+++ b/clippings-ingest.py
@@ -1,0 +1,151 @@
+# /// script
+# dependencies = []
+# ///
+"""
+clippings-ingest.py — Eigene Pipeline für Obsidian-Web-Clipper-Clips.
+
+Der Obsidian Web Clipper legt geclippte Web-Artikel als .md im Vault-Ordner
+`Clippings/` ab — außerhalb von raw/. Dadurch sieht der reguläre Watcher
+(watch.ps1, der nur raw/ überwacht) sie nie, und die Clips landen nie im
+Wiki-Index. Dieses Skript schließt die Lücke: es scannt `Clippings/`, ruft für
+jede neue bzw. geänderte .md den regulären ingest.py-Flow auf — fachlich
+identisch zu einer raw/links-Quelle (Web-Artikel) — und beendet sich.
+
+Designed für Scheduled-Task-Betrieb: ein Durchlauf, dann Exit. Der Task
+Scheduler taktet das Intervall (analog zu cron, siehe watchers.json). Den
+Bearbeitungs-State (path -> mtime) hält das Skript in .clippings-state.json,
+damit bereits verarbeitete Clips nicht bei jedem Lauf erneut durch das LLM
+gehen. (ingest.py schreibt für .md-Inputs keinen raw/.cache-Eintrag, daher
+braucht diese Pipeline einen eigenen State — wie scan-raw.py.)
+
+Usage:
+  uv run clippings-ingest.py                       # Single-Poll: neue/geänderte Clips
+  uv run clippings-ingest.py --force               # alle Clips erneut ingesten
+  uv run clippings-ingest.py --dry-run             # nur anzeigen, nichts ingesten
+  uv run clippings-ingest.py --clippings-dir PFAD  # abweichender Clippings-Ordner
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import logging
+import subprocess
+import sys
+from pathlib import Path
+
+WIKI_ROOT = Path(__file__).parent
+DEFAULT_CLIPPINGS_DIR = WIKI_ROOT / "Clippings"
+DEFAULT_STATE_FILE = WIKI_ROOT / ".clippings-state.json"
+
+sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8", errors="replace")
+sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding="utf-8", errors="replace")
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s  %(levelname)-8s  %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+    stream=sys.stderr,
+)
+log = logging.getLogger("clippings-ingest")
+
+
+def load_state(path: Path) -> dict[str, float]:
+    if path.exists():
+        try:
+            return json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            log.warning("State-Datei defekt — starte frisch: %s", path)
+    return {}
+
+
+def save_state(path: Path, state: dict[str, float]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(json.dumps(state, indent=2, sort_keys=True), encoding="utf-8")
+    tmp.replace(path)
+
+
+def parse_args() -> argparse.Namespace:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument("--clippings-dir", type=Path, default=DEFAULT_CLIPPINGS_DIR,
+                    help=f"Zu scannender Ordner (default: {DEFAULT_CLIPPINGS_DIR}).")
+    ap.add_argument("--state-file", type=Path, default=DEFAULT_STATE_FILE,
+                    help="JSON-Datei mit verarbeiteten Clips (path -> mtime).")
+    ap.add_argument("--force", action="store_true",
+                    help="State ignorieren und alle Clips erneut ingesten.")
+    ap.add_argument("--dry-run", action="store_true",
+                    help="Nur anzeigen, was ingestet würde — kein LLM-Aufruf.")
+    ap.add_argument("--timeout", type=int, default=600,
+                    help="Timeout pro Clip in Sekunden (default: 600).")
+    return ap.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+
+    clip_dir = args.clippings_dir.resolve()
+    if not clip_dir.is_dir():
+        # Kein Fehler: der Ordner existiert evtl. noch nicht, weil noch nichts
+        # geclippt wurde. Sauber beenden, damit der Scheduled Task nicht failt.
+        log.info("Clippings-Ordner nicht vorhanden (noch nichts geclippt?): %s", clip_dir)
+        return 0
+
+    state: dict[str, float] = {} if args.force else load_state(args.state_file)
+
+    files = sorted(
+        p for p in clip_dir.glob("**/*.md")
+        if p.is_file() and not p.name.startswith(".")
+    )
+    log.info("Scan %s: %d .md-Dateien, State kennt %d", clip_dir, len(files), len(state))
+
+    new_count = 0
+    failed = 0
+
+    for f in files:
+        rel = str(f.relative_to(clip_dir)).replace("\\", "/")
+        mtime = f.stat().st_mtime
+        if not args.force and state.get(rel) == mtime:
+            continue
+
+        if args.dry_run:
+            log.info("WÜRDE INGESTEN: %s", rel)
+            new_count += 1
+            continue
+
+        log.info("NEU/GEÄNDERT: %s", rel)
+        try:
+            proc = subprocess.run(
+                ["uv", "run", str(WIKI_ROOT / "ingest.py"), str(f)],
+                cwd=str(WIKI_ROOT),
+                timeout=args.timeout,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+            )
+            if proc.returncode == 0:
+                state[rel] = mtime
+                save_state(args.state_file, state)
+                new_count += 1
+                log.info("OK    %s", rel)
+            else:
+                failed += 1
+                tail = (proc.stderr or proc.stdout or "")[-500:]
+                log.error("FEHLER %s (exit %d)\n%s", rel, proc.returncode, tail)
+        except subprocess.TimeoutExpired:
+            failed += 1
+            log.error("TIMEOUT %s nach %ds", rel, args.timeout)
+        except Exception as e:  # noqa: BLE001 — Batch darf an einer Datei nicht sterben
+            failed += 1
+            log.error("EXCEPTION %s: %s", rel, e)
+
+    log.info("Fertig — %d verarbeitet, %d Fehler", new_count, failed)
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/watchers.json
+++ b/watchers.json
@@ -23,6 +23,14 @@
       "interval_minutes": 15,
       "timeout_minutes": 60,
       "description": "Pollt konfigurierte GitHub-Repos auf neue Commits und triggert die Code-Wiki-Pipeline."
+    },
+    {
+      "name": "WikiClippings",
+      "script": "clippings-ingest.py",
+      "args": [],
+      "interval_minutes": 15,
+      "timeout_minutes": 30,
+      "description": "Scannt den Obsidian-Web-Clipper-Ordner Clippings/ und ingestet neue/geänderte Web-Clips (.md) wie raw/links-Quellen."
     }
   ]
 }


### PR DESCRIPTION
Web pages clipped via the Obsidian Web Clipper land in the vault-root
Clippings/ folder, outside raw/. watch.ps1 only watches raw/, so these
clips were never ingested and never reached the wiki index.

clippings-ingest.py scans Clippings/**/*.md and routes each new/changed
file through the regular ingest.py flow (treated like a raw/links web
article). It keeps its own path->mtime state in .clippings-state.json
because ingest.py writes no raw/.cache entry for .md inputs, so the
cache-based dedup used by watch.ps1 does not apply here.

Wired up as local Scheduled Task "WikiClippings" (single-poll every
15 min) via watchers.json; cwd defaults to the repo root so no path
arguments are needed (avoids the arg-quoting limitation in
sync-watchers.ps1). Docs updated in CLAUDE.md, README.md, INTEGRATION.md;
Clippings/ and .clippings-state.json added to .gitignore.