### PR TITLE
Wissensschichten, Zugriffsrechte & Agenten-Gedächtnis (Epic #28) + graceful Links

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,7 +146,8 @@ uv run code-watch.py --loop     # Daemon-Modus (nur für Debugging)
 | `scan-raw.py` | Generischer File-Watcher (Polling-Wrapper für Projekte ohne eigenen Watcher) |
 | `rebuild-index.py` | Regeneriert `wiki/index.md` aus YAML-Frontmatter |
 | `rebuild-code-wiki-index.py` | Patcht Obsidian-Wikilinks in `wiki/code-wiki/` (Ticket-↔-Modul-Verlinkung) |
-| `lint-links.py` | Graceful Link-Checker: löst `[[wikilinks]]` + bundle-relative Links auf, meldet Broken Links & Waisen |
+| `lint-links.py` | Graceful Link-Checker: löst `[[wikilinks]]` + bundle-relative Links auf, meldet Broken Links & Waisen; prüft `visibility` |
+| `lint-tree.py` | Konsistenz-Check der Node-Rechte in `vault-tree.yaml` (read/write-Zonen vs. Hierarchie) |
 | `test-connection.py` | Smoke-Test der Azure-OpenAI- und GitHub-Verbindung |
 
 ---
@@ -350,6 +351,24 @@ Jede kuratierte Seite (`concepts/`, `entities/`, `sources/`, `syntheses/`) träg
   sie erben die Sichtbarkeit ihres Nodes (siehe T5). `lint-links.py` prüft sie daher nicht.
 - Prüfung: `uv run lint-links.py` meldet ungültige Werte und (mit
   `--show-missing-visibility`) Seiten ohne Feld.
+
+### Node-Rechte (`vault-tree.yaml`)
+
+Der Wissensbaum (`company → team → personal`) trägt pro Node ein `rights`-Block, das die
+Read-/Write-Zonen explizit macht (vorher implizit über SharePoint/OneDrive-ACL):
+
+```yaml
+rights:
+  clearance: internal           # höchste (restriktivste) Stufe, die der Node LESEN darf
+  default_visibility: internal  # Default-visibility für hier erzeugte Seiten (<= clearance)
+  read:  [self, <vorfahren>]    # nur nach oben lesen — keine seitlichen Leaks
+  write: [self, <nachfahren>]   # nach oben schreiben = Promotion (Review-Gate, T4)
+```
+
+- **Read nur nach oben:** ein Node liest sich selbst + Vorfahren, nie Geschwister-/Fremd-Nodes.
+- **Write nur nach unten:** Hochstufen in einen Eltern-Layer ist Promotion (T4), kein Default.
+- **`clearance` nimmt nach unten nicht ab** — sonst könnte ein Kind den Eltern-Layer nicht lesen.
+- Prüfung: `uv run lint-tree.py [--strict]` validiert diese Regeln gegen die Hierarchie.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,6 +234,7 @@ domain: ai | business | tech | cross
 sources: [raw/pdfs/paper1.pdf, raw/slides/vortrag2.pptx]
 related: ["[[anderes-konzept]]", "[[entity-name]]"]
 confidence: high | medium | low
+visibility: public | customer | internal | team | personal
 last_updated: YYYY-MM-DD
 ---
 ```
@@ -246,6 +247,7 @@ type: entity
 entity_type: person | company | product | organization
 sources: [raw/...]
 related: ["[[konzept]]"]
+visibility: public | customer | internal | team | personal
 last_updated: YYYY-MM-DD
 ---
 ```
@@ -259,6 +261,7 @@ source_file: raw/pdfs/dateiname.pdf
 source_type: paper | slide | doc | article | talk | transcript
 date: YYYY-MM-DD
 key_concepts: ["[[konzept-1]]", "[[konzept-2]]"]
+visibility: public | customer | internal | team | personal
 last_updated: YYYY-MM-DD
 ---
 ```
@@ -271,6 +274,7 @@ type: synthesis
 domain: ai | business | tech | cross
 sources: ["[[source-1]]", "[[source-2]]"]
 related: ["[[konzept]]"]
+visibility: public | customer | internal | team | personal
 last_updated: YYYY-MM-DD
 ---
 ```
@@ -319,6 +323,33 @@ keywords: [...]
 - Kapitel-Seiten mit Schritt-für-Schritt-Anleitungen, UI-Elementen fett
 - Bilder inline eingebettet: `![[dateiname.jpg]]`
 - Suche über Keywords, Querverweise auf andere Kapitel als `[[kapitel-slug]]`
+
+---
+
+## Sichtbarkeit & Wissensschichten
+
+Jede kuratierte Seite (`concepts/`, `entities/`, `sources/`, `syntheses/`) trägt ein
+`visibility:`-Feld, das die **Wissensschicht** klassifiziert — von offen nach restriktiv:
+
+| Stufe | Wer darf lesen |
+|-------|----------------|
+| `public`   | extern sichtbar, keine Einschränkung |
+| `customer` | Kunden / externe Software-User eines Produkts |
+| `internal` | alle Firmenmitarbeiter |
+| `team`     | nur das jeweilige Team (Node) |
+| `personal` | nur der Eigentümer-Node |
+
+- **Default (Feld fehlt) = `personal`** — *safe by default*: lieber zu restriktiv als
+  versehentlich geleakt. Ein fehlendes Feld ist kein Fehler, nur ein Lint-Hinweis.
+- **OKF-kompatibel:** `visibility` ist ein Custom-Key; Consumer, die es nicht kennen,
+  dürfen die Seite nicht verwerfen (graceful degradation).
+- Die Stufe ist eine **Klassifizierung, keine Sicherheitsgrenze** — die Durchsetzung
+  („`visibility ≤ clearance`" vor der Kontextbefüllung) gehört in den Retrieval-Layer
+  (siehe Epic #28, T3), nicht in die Markdown-Datei.
+- **Auto-generierte Bundles** (`code-wiki/`, `manuals/`) tragen *kein* Feld pro Seite —
+  sie erben die Sichtbarkeit ihres Nodes (siehe T5). `lint-links.py` prüft sie daher nicht.
+- Prüfung: `uv run lint-links.py` meldet ungültige Werte und (mit
+  `--show-missing-visibility`) Seiten ohne Feld.
 
 ---
 
@@ -390,8 +421,9 @@ Wenn der Nutzer "lint" oder "wiki aufräumen" sagt:
 
 Erst **deterministisch** vorprüfen, dann inhaltlich:
 ```bash
-uv run lint-links.py            # Broken Links (beide Formen) + Waisen
-uv run lint-links.py --strict   # Exit 1 bei Broken Links (für CI/Watcher)
+uv run lint-links.py                          # Broken Links + Waisen + ungültige visibility
+uv run lint-links.py --show-missing-visibility # zusätzlich: Seiten ohne visibility-Feld
+uv run lint-links.py --strict                 # Exit 1 bei Broken Links / ungültiger visibility
 ```
 
 Prüfe die Wiki auf:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,6 +146,7 @@ uv run code-watch.py --loop     # Daemon-Modus (nur für Debugging)
 | `scan-raw.py` | Generischer File-Watcher (Polling-Wrapper für Projekte ohne eigenen Watcher) |
 | `rebuild-index.py` | Regeneriert `wiki/index.md` aus YAML-Frontmatter |
 | `rebuild-code-wiki-index.py` | Patcht Obsidian-Wikilinks in `wiki/code-wiki/` (Ticket-↔-Modul-Verlinkung) |
+| `lint-links.py` | Graceful Link-Checker: löst `[[wikilinks]]` + bundle-relative Links auf, meldet Broken Links & Waisen |
 | `test-connection.py` | Smoke-Test der Azure-OpenAI- und GitHub-Verbindung |
 
 ---
@@ -328,6 +329,22 @@ keywords: [...]
 - Bilder einbetten: `![[dateiname.jpg]]` (Obsidian-Syntax)
 - Neue Konzepte ohne Seite: als `[[neues-konzept]]` verlinken, dann Seite anlegen
 
+### Portable Links (bundle-relativ) — optional
+`[[wikilinks]]` sind die Obsidian-native Default-Form und bleiben es. Wo ein Link
+**außerhalb von Obsidian** stabil bleiben muss (GitHub-Rendering, Archiv-Repo, fremde
+Tools), ist zusätzlich die **bundle-relative** Form erlaubt — angelehnt an das
+[Open Knowledge Format](https://github.com/GoogleCloudPlatform/knowledge-catalog/tree/main/okf):
+ein Markdown-Link, dessen Pfad mit `/` ab dem `wiki/`-Root beginnt.
+
+```markdown
+[OpenAI](/entities/openai.md)        # bundle-relativ, ab wiki/ — portabel
+[[openai]]                            # Obsidian-Wikilink — Default
+```
+
+- `lint-links.py` löst **beide** Formen auf und prüft sie (siehe Operation: LINT).
+- Regel wie bei OKF: Links sind gerichtete Kanten; ein kaputtes Ziel ist **kein Fehler,
+  der etwas abbricht**, sondern ein Lint-Befund (Ziel ggf. noch anzulegen).
+
 ---
 
 ## Operation: INGEST
@@ -371,6 +388,12 @@ Wenn der Nutzer eine inhaltliche Frage stellt:
 
 Wenn der Nutzer "lint" oder "wiki aufräumen" sagt:
 
+Erst **deterministisch** vorprüfen, dann inhaltlich:
+```bash
+uv run lint-links.py            # Broken Links (beide Formen) + Waisen
+uv run lint-links.py --strict   # Exit 1 bei Broken Links (für CI/Watcher)
+```
+
 Prüfe die Wiki auf:
 - **Widersprüche:** Seiten die widersprüchliche Aussagen machen → markieren mit `> ⚠️ Widerspruch zu [[andere-seite]]`
 - **Waisen:** Seiten ohne eingehende Links → verlinken oder in index.md aufnehmen
@@ -402,6 +425,10 @@ Report als strukturierte Liste, dann Fixes durchführen.
 - **Immer** `index.md` aktualisieren wenn neue Seiten in concepts/entities/sources/syntheses angelegt werden
 - Bestehende Seiten erweitern statt Duplikate anlegen
 - Bei Unsicherheit über Kategorisierung: `domain: cross` verwenden
+- **Graceful degradation** (OKF-Prinzip „tolerate, don't reject"): Pipeline-Skripte, die über
+  viele Seiten iterieren, dürfen an einer fehlerhaften Einzelseite **nie den ganzen Lauf
+  abbrechen** — Seite überspringen, Warnung loggen, weitermachen. Unbekannte Frontmatter-Felder,
+  unbekannte `type`-Werte und kaputte Links werden toleriert, nicht verworfen.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -370,6 +370,34 @@ rights:
 - **`clearance` nimmt nach unten nicht ab** — sonst könnte ein Kind den Eltern-Layer nicht lesen.
 - Prüfung: `uv run lint-tree.py [--strict]` validiert diese Regeln gegen die Hierarchie.
 
+### Agenten-Capabilities (`vault-tree.yaml` › `agents:`)
+
+Ein Agent erhält ein Capability-Profil, das `clearance` (Lese-Obergrenze) mit Read-/Write-Scope
+verbindet. **Effektiver Lesezugriff** auf eine Seite:
+
+> `rank(visibility) <= rank(clearance)`  **und**  `node(seite) ∈ read_scope`
+
+```yaml
+agents:
+  - id: <slug>
+    clearance: <stufe>          # höchste visibility, die der Agent lesen darf
+    read_scope:  [<node>, ...]  # Nodes, deren Inhalt sichtbar ist
+    write_scope: <node> | session   # 'session' = ephemerer Sandbox-Node (kein Persist)
+```
+
+Zwei Referenz-Profile (in `vault-tree.yaml.example`):
+
+| Profil | clearance | read_scope | write_scope |
+|--------|-----------|------------|-------------|
+| **Produkt-Agent** (externe Software-User) | `customer` | freigegebene Nodes (z.B. `company`) | `session` (Sandbox) |
+| **Interner Team-Copilot** | `team` | eigener Team-Node + `company` | eigener Team-Node |
+
+Regeln (von `lint-tree.py` geprüft): `read_scope`/`write_scope` müssen existierende Nodes
+referenzieren; ein Agent darf nicht in einen Node schreiben, dessen Default-Sichtbarkeit über
+seiner `clearance` liegt (er könnte die Seite nicht zurücklesen); Low-Trust-Agenten
+(`clearance ≤ customer`) sollten in einen `session`-Sandbox schreiben statt in einen
+persistenten Node (Promotion → T4). **Durchsetzung** des Filters erfolgt im Retrieval-Layer (T3).
+
 ---
 
 ## Wikilink-Konvention

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,6 +148,7 @@ uv run code-watch.py --loop     # Daemon-Modus (nur für Debugging)
 | `rebuild-code-wiki-index.py` | Patcht Obsidian-Wikilinks in `wiki/code-wiki/` (Ticket-↔-Modul-Verlinkung) |
 | `lint-links.py` | Graceful Link-Checker: löst `[[wikilinks]]` + bundle-relative Links auf, meldet Broken Links & Waisen; prüft `visibility` |
 | `lint-tree.py` | Konsistenz-Check der Node-Rechte in `vault-tree.yaml` (read/write-Zonen vs. Hierarchie) |
+| `access.py` | Retrieval-Filter-Bibliothek: `can_read`/`filter_readable` (visibility-Durchsetzung, fail closed) — *single source of truth* der visibility-Leiter |
 | `test-connection.py` | Smoke-Test der Azure-OpenAI- und GitHub-Verbindung |
 
 ---
@@ -396,7 +397,27 @@ Regeln (von `lint-tree.py` geprüft): `read_scope`/`write_scope` müssen existie
 referenzieren; ein Agent darf nicht in einen Node schreiben, dessen Default-Sichtbarkeit über
 seiner `clearance` liegt (er könnte die Seite nicht zurücklesen); Low-Trust-Agenten
 (`clearance ≤ customer`) sollten in einen `session`-Sandbox schreiben statt in einen
-persistenten Node (Promotion → T4). **Durchsetzung** des Filters erfolgt im Retrieval-Layer (T3).
+persistenten Node (Promotion → T4).
+
+### Durchsetzung: Retrieval-Filter (`access.py`)
+
+Die Klassifizierung ist nur dann eine Grenze, wenn sie **vor** der Kontextbefüllung
+durchgesetzt wird. `access.py` ist die wiederverwendbare Bibliothek dafür (und die *single
+source of truth* der visibility-Leiter — `lint-links.py`/`lint-tree.py` importieren sie):
+
+```python
+from access import AgentProfile, Page, can_read, filter_readable
+
+agent = AgentProfile("prod", clearance="customer",
+                     read_scope=frozenset({"company"}), write_scope="session")
+visible = filter_readable(candidate_pages, agent)   # Gate vor dem Kontextfenster
+```
+
+- **Lesbar ⇔** `rank(visibility) ≤ rank(clearance)` **und** `node ∈ read_scope`.
+- **Fail closed:** fehlende/ungültige Seiten-`visibility` → `personal` (verbergen); fehlende/
+  ungültige Agenten-`clearance` → `public` (geringster Zugriff). Unbekanntes leakt nie.
+- Tests: `uv run --no-project python -m unittest test_access` (Fokus: kein Leakage).
+- Reiner Stdlib-Code → von jedem Retrieval-Layer (Produkt-Agent, MCP-Server) importierbar.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,6 +149,7 @@ uv run code-watch.py --loop     # Daemon-Modus (nur für Debugging)
 | `lint-links.py` | Graceful Link-Checker: löst `[[wikilinks]]` + bundle-relative Links auf, meldet Broken Links & Waisen; prüft `visibility` |
 | `lint-tree.py` | Konsistenz-Check der Node-Rechte in `vault-tree.yaml` (read/write-Zonen vs. Hierarchie) |
 | `access.py` | Retrieval-Filter-Bibliothek: `can_read`/`filter_readable` (visibility-Durchsetzung, fail closed) — *single source of truth* der visibility-Leiter |
+| `promote.py` | Promotion-Planner: validiert Hochstufen einer Seite in einen Vorfahr-Node (Review-Gate, kein Auto-Move) |
 | `test-connection.py` | Smoke-Test der Azure-OpenAI- und GitHub-Verbindung |
 
 ---
@@ -418,6 +419,30 @@ visible = filter_readable(candidate_pages, agent)   # Gate vor dem Kontextfenste
   ungültige Agenten-`clearance` → `public` (geringster Zugriff). Unbekanntes leakt nie.
 - Tests: `uv run --no-project python -m unittest test_access` (Fokus: kein Leakage).
 - Reiner Stdlib-Code → von jedem Retrieval-Layer (Produkt-Agent, MCP-Server) importierbar.
+
+### Agenten-Gedächtnis & Promotion
+
+Das Wiki kann **Langzeitgedächtnis eines Agenten** sein. Dafür gilt:
+
+**Schreibzonen** (aus dem `write_scope` des Agentenprofils, T2):
+- **`session`** — ephemerer Sandbox-Node, kein Persist im Baum. Default für Low-Trust-/
+  Produkt-Agenten: externer Input vergiftet so nie das persistente Gedächtnis.
+- **persistenter Node** (z.B. eigener `personal`-/`team`-Node) — nur für vertrauenswürdige
+  interne Agenten. Ein Agent schreibt **ausschließlich** in seinen `write_scope` (`access.can_write`).
+
+**Memory-Schichten** (mappen auf bestehende Seitentypen):
+- **episodisch** → `log.md` (append-only): was wann passiert ist.
+- **semantisch** → `concepts/` + `entities/`: verdichtetes, vernetztes Wissen (Graph).
+- **prozedural/Quellen** → `sources/`: woher eine Erkenntnis stammt (Provenienz).
+
+**Promotion** (Hochstufen in einen breiteren Layer):
+- Wissen entsteht im engen Node (`session`/`personal`) und wird erst nach **Review** in
+  `team` → `company` gehoben — Promotion verbreitert die Sichtbarkeit und ist nie automatisch.
+- Regeln: Ziel-Node muss **Vorfahr** sein (nur nach oben); Ziel-Sichtbarkeit =
+  `default_visibility` des Ziel-Nodes und muss das Publikum verbreitern.
+- `uv run promote.py --from <node> --to <node> --visibility <stufe>` **plant und validiert**
+  die Promotion (permissibel? resultierende Sichtbarkeit?), führt sie aber nicht aus — der
+  Move + Review-Vermerk in `log.md` bleibt ein bewusster manueller Schritt (T4-Gate).
 
 ---
 

--- a/access.py
+++ b/access.py
@@ -1,0 +1,103 @@
+"""access.py — Wiederverwendbarer Retrieval-Filter für Wissensschichten (Epic #28 / T3).
+
+Single source of truth für die visibility-Leiter (importiert von lint-links.py & lint-tree.py)
+und Durchsetzung des Sichtbarkeitsmodells *vor* der Kontextbefüllung:
+
+    Eine Seite ist für einen Agenten lesbar  ⇔
+        rank(visibility) <= rank(clearance)   UND   node(seite) ∈ read_scope
+
+Wichtig (OKF / safe by default): unbekannte/fehlende Werte **fail closed**:
+  - fehlende/ungültige Seiten-`visibility`  → restriktivste Stufe (`personal`)  → eher verbergen
+  - fehlende/ungültige Agenten-`clearance`   → niedrigste Stufe (`public`)        → weniger Zugriff
+
+Reine Standardbibliothek — ohne Abhängigkeiten importierbar und testbar.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# Sichtbarkeits-Schichten, von offen (Index 0) nach restriktiv (Index -1).
+VISIBILITY_LEVELS = ["public", "customer", "internal", "team", "personal"]
+
+DEFAULT_VISIBILITY = VISIBILITY_LEVELS[-1]   # fehlende Seiten-visibility → restriktivste Stufe
+LEAST_CLEARANCE = VISIBILITY_LEVELS[0]       # fehlende Agenten-clearance → geringster Zugriff
+SESSION = "session"                          # ephemerer Sandbox-Node (kein Persist im Baum)
+
+
+def rank(level: str) -> int:
+    """Sensitivitäts-Rang einer visibility-Stufe (höher = restriktiver)."""
+    return VISIBILITY_LEVELS.index(level)
+
+
+def _clean(value: str) -> str:
+    return value.strip().strip('"').strip("'").lower()
+
+
+def normalize_visibility(value: str | None) -> str:
+    """Seiten-visibility normalisieren. Unbekannt/fehlend → restriktivster Default (verbergen)."""
+    if value is None:
+        return DEFAULT_VISIBILITY
+    v = _clean(value)
+    return v if v in VISIBILITY_LEVELS else DEFAULT_VISIBILITY
+
+
+def normalize_clearance(value: str | None) -> str:
+    """Agenten-clearance normalisieren. Unbekannt/fehlend → geringster Zugriff (fail closed)."""
+    if value is None:
+        return LEAST_CLEARANCE
+    v = _clean(value)
+    return v if v in VISIBILITY_LEVELS else LEAST_CLEARANCE
+
+
+@dataclass(frozen=True)
+class AgentProfile:
+    """Capability eines Agenten (T2): clearance + read/write-Scope."""
+    id: str
+    clearance: str
+    read_scope: frozenset[str]
+    write_scope: str = SESSION
+
+    @property
+    def clearance_rank(self) -> int:
+        return rank(self.clearance)
+
+
+@dataclass(frozen=True)
+class Page:
+    """Minimal-Sicht auf eine Wiki-Seite für die Zugriffsprüfung."""
+    node: str
+    visibility: str
+    ref: str = ""    # optional: Pfad/ID für Reporting
+
+
+def can_read(page: Page, agent: AgentProfile) -> bool:
+    """True, wenn der Agent die Seite lesen darf. Fail closed bei unbekannten Werten."""
+    if page.node not in agent.read_scope:
+        return False
+    return rank(normalize_visibility(page.visibility)) <= rank(normalize_clearance(agent.clearance))
+
+
+def filter_readable(pages, agent: AgentProfile) -> list[Page]:
+    """Filtert eine Seiten-Sequenz auf die für den Agenten lesbaren Seiten (Retrieval-Gate)."""
+    return [p for p in pages if can_read(p, agent)]
+
+
+def can_write(agent: AgentProfile, node: str) -> bool:
+    """True, wenn der Agent in `node` schreiben darf (nur in den eigenen write_scope)."""
+    return node == agent.write_scope
+
+
+def load_agents(tree_data: dict) -> dict[str, AgentProfile]:
+    """Baut AgentProfile-Objekte aus einem geparsten vault-tree.yaml (Schlüssel: agent-id)."""
+    out: dict[str, AgentProfile] = {}
+    for a in tree_data.get("agents", []) or []:
+        if not isinstance(a, dict) or not a.get("id"):
+            continue
+        out[a["id"]] = AgentProfile(
+            id=a["id"],
+            clearance=normalize_clearance(a.get("clearance")),
+            read_scope=frozenset(a.get("read_scope", []) or []),
+            write_scope=a.get("write_scope", SESSION),
+        )
+    return out

--- a/lint-links.py
+++ b/lint-links.py
@@ -48,8 +48,19 @@ VAULT_ROOT = Path(os.environ.get("VAULT_ROOT", str(SCRIPT_ROOT)))
 # Reservierte Dateinamen (OKF) + generierte Indizes — nie als Waise melden.
 RESERVED = {"index.md", "log.md", "picture_index.md", "changelog.md", "image-index.md"}
 
+# Sichtbarkeits-Schichten, von offen (links) nach restriktiv (rechts).
+# Default für Seiten OHNE Feld = restriktivste Stufe (safe by default).
+VISIBILITY_LEVELS = ["public", "customer", "internal", "team", "personal"]
+DEFAULT_VISIBILITY = VISIBILITY_LEVELS[-1]
+
+# Seitentypen, für die eine visibility-Klassifizierung erwartet wird.
+# code-wiki/ und manuals/ erben Node-Sichtbarkeit (T5) → hier nicht geprüft.
+VISIBILITY_SCOPE = ("concepts", "entities", "sources", "syntheses")
+
 WIKILINK_RE = re.compile(r"!?\[\[([^\]]+?)\]\]")
 MDLINK_RE = re.compile(r"\[[^\]]*\]\(([^)]+)\)")
+FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---", re.DOTALL)
+VISIBILITY_RE = re.compile(r"^visibility:\s*(.+)$", re.MULTILINE)
 
 
 def is_external(target: str) -> bool:
@@ -117,6 +128,17 @@ def resolve(target: str, src: Path, wiki_dir: Path,
     return hits[0] if hits else None
 
 
+def read_visibility(text: str) -> str | None:
+    """visibility aus dem Frontmatter lesen. None = Feld fehlt (→ Default gilt)."""
+    fm = FRONTMATTER_RE.search(text)
+    if not fm:
+        return None
+    vm = VISIBILITY_RE.search(fm.group(1))
+    if not vm:
+        return None
+    return vm.group(1).strip().strip('"').strip("'").lower()
+
+
 def extract_targets(text: str) -> list[str]:
     """Alle internen Link-Ziele einer Seite (Wikilinks + Markdown-Links)."""
     targets = [normalize_wikilink(m) for m in WIKILINK_RE.findall(text)]
@@ -127,8 +149,11 @@ def extract_targets(text: str) -> list[str]:
 def main() -> int:
     parser = argparse.ArgumentParser(description="Graceful Link-Checker für die Wiki (OKF)")
     parser.add_argument("--wiki-dir", help="Wiki-Verzeichnis (Default: $VAULT_ROOT/wiki)")
-    parser.add_argument("--strict", action="store_true", help="Exit 1 bei Broken Links")
+    parser.add_argument("--strict", action="store_true",
+                        help="Exit 1 bei Broken Links oder ungültiger visibility")
     parser.add_argument("--no-orphans", action="store_true", help="Waisen-Analyse überspringen")
+    parser.add_argument("--show-missing-visibility", action="store_true",
+                        help="Seiten ohne visibility-Feld einzeln auflisten")
     args = parser.parse_args()
 
     wiki_dir = Path(args.wiki_dir) if args.wiki_dir else VAULT_ROOT / "wiki"
@@ -140,23 +165,33 @@ def main() -> int:
 
     broken: list[tuple[str, str]] = []          # (quelle, ziel)
     incoming: set[Path] = set()                 # Seiten mit eingehendem Link
+    invalid_vis: list[tuple[str, str]] = []     # (quelle, ungültiger wert)
+    missing_vis: list[str] = []                 # quelle ohne visibility-Feld
     skipped = 0
 
     for page in md_pages:
+        rel = page.relative_to(wiki_dir)
         try:
             text = page.read_text(encoding="utf-8")
         except (OSError, UnicodeDecodeError) as exc:
             skipped += 1
-            print(f"  ! SKIP {page.relative_to(wiki_dir).as_posix()} — "
-                  f"{type(exc).__name__}: {exc}", file=sys.stderr)
+            print(f"  ! SKIP {rel.as_posix()} — {type(exc).__name__}: {exc}", file=sys.stderr)
             continue
 
         for target in extract_targets(text):
             dest = resolve(target, page, wiki_dir, rel_index, stem_index)
             if dest is None:
-                broken.append((page.relative_to(wiki_dir).as_posix(), target))
+                broken.append((rel.as_posix(), target))
             elif dest != page:
                 incoming.add(dest.resolve())
+
+        # visibility nur für kuratierte Seitentypen prüfen
+        if rel.parts and rel.parts[0] in VISIBILITY_SCOPE:
+            vis = read_visibility(text)
+            if vis is None:
+                missing_vis.append(rel.as_posix())
+            elif vis not in VISIBILITY_LEVELS:
+                invalid_vis.append((rel.as_posix(), vis))
 
     # --- Report -----------------------------------------------------------
     print(f"Wiki: {wiki_dir}  ({len(md_pages)} Seiten, {skipped} übersprungen)\n")
@@ -179,7 +214,22 @@ def main() -> int:
         if not orphans:
             print("  (keine)")
 
-    return 1 if (args.strict and broken) else 0
+    print(f"\n## visibility — ungültige Werte ({len(invalid_vis)})")
+    for src, val in invalid_vis:
+        print(f"  ✗ {src} → '{val}'  (erlaubt: {', '.join(VISIBILITY_LEVELS)})")
+    if not invalid_vis:
+        print("  (keine)")
+
+    print(f"\n## visibility — fehlt, Default '{DEFAULT_VISIBILITY}' ({len(missing_vis)})")
+    if missing_vis and args.show_missing_visibility:
+        for src in sorted(missing_vis):
+            print(f"  ○ {src}")
+    elif missing_vis:
+        print(f"  ({len(missing_vis)} Seiten — mit --show-missing-visibility auflisten)")
+    else:
+        print("  (keine)")
+
+    return 1 if (args.strict and (broken or invalid_vis)) else 0
 
 
 if __name__ == "__main__":

--- a/lint-links.py
+++ b/lint-links.py
@@ -1,0 +1,186 @@
+# /// script
+# dependencies = ["python-dotenv"]
+# ///
+"""
+lint-links.py — Graceful Link-Checker für die Wiki (OKF-Prinzip).
+
+Löst BEIDE internen Link-Formen auf und meldet Probleme, statt abzubrechen:
+  1. Obsidian-Wikilinks      [[seiten-slug]], [[slug|alias]], [[slug#heading]], ![[bild.jpg]]
+  2. Bundle-relative Links   [text](/concepts/foo.md)   — ab wiki/-Root, portable/stabile Form
+     + gewöhnliche relative  [text](../entities/bar.md)
+
+OKF-Konformität (siehe SPEC.md des knowledge-catalog/okf):
+  - Links sind gerichtete Kanten; kaputte Ziele werden TOLERIERT (Report, kein Crash).
+  - Eine fehlerhafte Einzelseite bricht den Lauf nie ab (graceful degradation).
+
+Report:
+  - Broken Links : [[..]]/(..) ohne existierendes Ziel
+  - Waisen       : Seiten ohne eingehende Links (außer index/log/picture_index)
+
+Usage:
+    uv run lint-links.py                 # Report über $VAULT_ROOT/wiki
+    uv run lint-links.py --wiki-dir PATH # abweichendes Wiki-Verzeichnis
+    uv run lint-links.py --strict        # Exit-Code 1 wenn Broken Links gefunden
+    uv run lint-links.py --no-orphans    # nur Broken Links prüfen
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+try:
+    from dotenv import load_dotenv
+    _vault = os.environ.get("VAULT_ROOT")
+    if _vault:
+        load_dotenv(Path(_vault) / ".env", override=False)
+    load_dotenv(Path(__file__).parent / ".env", override=False)
+except ImportError:
+    pass
+
+SCRIPT_ROOT = Path(__file__).parent
+VAULT_ROOT = Path(os.environ.get("VAULT_ROOT", str(SCRIPT_ROOT)))
+
+# Reservierte Dateinamen (OKF) + generierte Indizes — nie als Waise melden.
+RESERVED = {"index.md", "log.md", "picture_index.md", "changelog.md", "image-index.md"}
+
+WIKILINK_RE = re.compile(r"!?\[\[([^\]]+?)\]\]")
+MDLINK_RE = re.compile(r"\[[^\]]*\]\(([^)]+)\)")
+
+
+def is_external(target: str) -> bool:
+    """http(s)://, mailto:, reine Anker (#...) etc. sind keine internen Seiten-Links."""
+    t = target.strip()
+    return (
+        not t
+        or t.startswith(("http://", "https://", "mailto:", "#"))
+        or "://" in t.split("/", 1)[0]
+    )
+
+
+def normalize_wikilink(raw: str) -> str:
+    """[[slug|alias]] / [[slug#heading]] / [[folder/slug]] → bloßes Ziel (vor | und #)."""
+    target = raw.split("|", 1)[0]
+    target = target.split("#", 1)[0]
+    return target.strip()
+
+
+def collect_pages(wiki_dir: Path) -> tuple[dict[str, Path], dict[str, list[Path]], list[Path]]:
+    """
+    Indiziert alle Dateien unter wiki/.
+      rel_index : bundle-relativer Pfad (mit/ohne .md, posix) → Path
+      stem_index: Dateiname-Stem → [Paths]  (Wikilink-Auflösung; Kollisionen möglich)
+      md_pages  : alle .md-Seiten (für Waisen-Analyse)
+    """
+    rel_index: dict[str, Path] = {}
+    stem_index: dict[str, list[Path]] = defaultdict(list)
+    md_pages: list[Path] = []
+
+    for f in sorted(wiki_dir.rglob("*")):
+        if not f.is_file() or ".git" in f.parts:
+            continue
+        rel = f.relative_to(wiki_dir).as_posix()
+        rel_index[rel] = f
+        if f.suffix == ".md":
+            rel_index[rel[: -len(".md")]] = f  # auch ohne Endung adressierbar
+            md_pages.append(f)
+        stem_index[f.stem].append(f)
+
+    return rel_index, stem_index, md_pages
+
+
+def resolve(target: str, src: Path, wiki_dir: Path,
+            rel_index: dict[str, Path], stem_index: dict[str, list[Path]]) -> Path | None:
+    """Löst ein Link-Ziel (Wikilink-Slug ODER Pfad) auf eine existierende Datei auf."""
+    t = target.strip()
+    if not t:
+        return None
+
+    # Bundle-relativ ("/concepts/foo.md") — ab wiki/-Root
+    if t.startswith("/"):
+        rel = t.lstrip("/")
+        return rel_index.get(rel) or rel_index.get(rel.removesuffix(".md"))
+
+    # Pfad-artig (enthält "/" oder ".md"-Endung) → relativ zur Quelldatei, dann bundle-relativ
+    if "/" in t or t.endswith(".md"):
+        cand = (src.parent / t).resolve()
+        if cand.is_file():
+            return cand
+        return rel_index.get(t) or rel_index.get(t.removesuffix(".md"))
+
+    # Reiner Wikilink-Slug → über Dateiname-Stem
+    hits = stem_index.get(t)
+    return hits[0] if hits else None
+
+
+def extract_targets(text: str) -> list[str]:
+    """Alle internen Link-Ziele einer Seite (Wikilinks + Markdown-Links)."""
+    targets = [normalize_wikilink(m) for m in WIKILINK_RE.findall(text)]
+    targets += [m for m in MDLINK_RE.findall(text) if not is_external(m)]
+    return [t for t in targets if t]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Graceful Link-Checker für die Wiki (OKF)")
+    parser.add_argument("--wiki-dir", help="Wiki-Verzeichnis (Default: $VAULT_ROOT/wiki)")
+    parser.add_argument("--strict", action="store_true", help="Exit 1 bei Broken Links")
+    parser.add_argument("--no-orphans", action="store_true", help="Waisen-Analyse überspringen")
+    args = parser.parse_args()
+
+    wiki_dir = Path(args.wiki_dir) if args.wiki_dir else VAULT_ROOT / "wiki"
+    if not wiki_dir.is_dir():
+        print(f"ERROR: Wiki-Verzeichnis nicht gefunden: {wiki_dir}", file=sys.stderr)
+        return 2
+
+    rel_index, stem_index, md_pages = collect_pages(wiki_dir)
+
+    broken: list[tuple[str, str]] = []          # (quelle, ziel)
+    incoming: set[Path] = set()                 # Seiten mit eingehendem Link
+    skipped = 0
+
+    for page in md_pages:
+        try:
+            text = page.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as exc:
+            skipped += 1
+            print(f"  ! SKIP {page.relative_to(wiki_dir).as_posix()} — "
+                  f"{type(exc).__name__}: {exc}", file=sys.stderr)
+            continue
+
+        for target in extract_targets(text):
+            dest = resolve(target, page, wiki_dir, rel_index, stem_index)
+            if dest is None:
+                broken.append((page.relative_to(wiki_dir).as_posix(), target))
+            elif dest != page:
+                incoming.add(dest.resolve())
+
+    # --- Report -----------------------------------------------------------
+    print(f"Wiki: {wiki_dir}  ({len(md_pages)} Seiten, {skipped} übersprungen)\n")
+
+    print(f"## Broken Links ({len(broken)})")
+    for src, target in broken:
+        print(f"  ✗ {src} → {target}")
+    if not broken:
+        print("  (keine)")
+
+    if not args.no_orphans:
+        orphans = [
+            p.relative_to(wiki_dir).as_posix()
+            for p in md_pages
+            if p.name not in RESERVED and p.resolve() not in incoming
+        ]
+        print(f"\n## Waisen — ohne eingehende Links ({len(orphans)})")
+        for o in sorted(orphans):
+            print(f"  ○ {o}")
+        if not orphans:
+            print("  (keine)")
+
+    return 1 if (args.strict and broken) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/lint-links.py
+++ b/lint-links.py
@@ -45,13 +45,10 @@ except ImportError:
 SCRIPT_ROOT = Path(__file__).parent
 VAULT_ROOT = Path(os.environ.get("VAULT_ROOT", str(SCRIPT_ROOT)))
 
+from access import DEFAULT_VISIBILITY, VISIBILITY_LEVELS  # Single source of truth (T3)
+
 # Reservierte Dateinamen (OKF) + generierte Indizes — nie als Waise melden.
 RESERVED = {"index.md", "log.md", "picture_index.md", "changelog.md", "image-index.md"}
-
-# Sichtbarkeits-Schichten, von offen (links) nach restriktiv (rechts).
-# Default für Seiten OHNE Feld = restriktivste Stufe (safe by default).
-VISIBILITY_LEVELS = ["public", "customer", "internal", "team", "personal"]
-DEFAULT_VISIBILITY = VISIBILITY_LEVELS[-1]
 
 # Seitentypen, für die eine visibility-Klassifizierung erwartet wird.
 # code-wiki/ und manuals/ erben Node-Sichtbarkeit (T5) → hier nicht geprüft.

--- a/lint-tree.py
+++ b/lint-tree.py
@@ -36,16 +36,10 @@ try:
 except ImportError:
     pass
 
+from access import VISIBILITY_LEVELS, rank  # Single source of truth (T3)
+
 SCRIPT_ROOT = Path(__file__).parent
 VAULT_ROOT = Path(os.environ.get("VAULT_ROOT", str(SCRIPT_ROOT)))
-
-# Sichtbarkeits-Schichten, von offen (Index 0) nach restriktiv. Muss zu lint-links.py passen.
-VISIBILITY_LEVELS = ["public", "customer", "internal", "team", "personal"]
-
-
-def rank(level: str) -> int:
-    """Sensitivitäts-Rang einer visibility-Stufe (höher = restriktiver)."""
-    return VISIBILITY_LEVELS.index(level)
 
 
 def load_tree(path: Path) -> dict:

--- a/lint-tree.py
+++ b/lint-tree.py
@@ -155,8 +155,46 @@ def main() -> int:
                     warns.append(f"{name}: clearance '{clearance}' niedriger als Eltern "
                                  f"'{parent}' ({p_rights['clearance']}) — kann Eltern-Layer nicht lesen")
 
+    # --- Agenten-Capability-Profile (T2) ----------------------------------
+    rights_of = {n["node"]: n.get("rights") for n in nodes
+                 if isinstance(n, dict) and n.get("node")}
+    agents = data.get("agents", []) or []
+
+    for a in agents:
+        if not isinstance(a, dict) or not a.get("id"):
+            warns.append(f"Agent-Eintrag ohne 'id' übersprungen: {a!r}")
+            continue
+        aid = a["id"]
+        clearance = a.get("clearance")
+
+        if clearance not in VISIBILITY_LEVELS:
+            errors.append(f"agent {aid}: ungültige clearance '{clearance}' "
+                          f"(erlaubt: {', '.join(VISIBILITY_LEVELS)})")
+
+        for r in a.get("read_scope", []) or []:
+            if r not in names:
+                errors.append(f"agent {aid}: read_scope-Node '{r}' existiert nicht im Baum")
+
+        ws = a.get("write_scope")
+        if ws != "session" and ws not in names:
+            errors.append(f"agent {aid}: write_scope '{ws}' ist weder 'session' noch ein Node im Baum")
+
+        # Low-Trust-Agent (sieht nur bis customer) sollte ephemer schreiben, nicht persistent
+        if clearance in VISIBILITY_LEVELS and rank(clearance) <= rank("customer") \
+                and ws in names:
+            warns.append(f"agent {aid}: niedrige clearance '{clearance}' schreibt in persistenten "
+                         f"Node '{ws}' — Sandbox/'session' empfohlen (T4)")
+
+        # Agent darf nicht in einen Node schreiben, dessen Seiten er nicht lesen könnte
+        if ws in names and clearance in VISIBILITY_LEVELS:
+            wr = rights_of.get(ws)
+            if isinstance(wr, dict) and wr.get("default_visibility") in VISIBILITY_LEVELS \
+                    and rank(wr["default_visibility"]) > rank(clearance):
+                errors.append(f"agent {aid}: write_scope '{ws}' erzeugt Seiten (default_visibility "
+                              f"'{wr['default_visibility']}') über clearance '{clearance}' — unlesbar")
+
     # --- Report -----------------------------------------------------------
-    print(f"vault-tree: {config}  ({len(nodes)} Nodes)\n")
+    print(f"vault-tree: {config}  ({len(nodes)} Nodes, {len(agents)} Agenten)\n")
 
     print(f"## ERROR ({len(errors)})")
     for e in errors:

--- a/lint-tree.py
+++ b/lint-tree.py
@@ -1,0 +1,177 @@
+# /// script
+# dependencies = ["pyyaml", "python-dotenv"]
+# ///
+"""
+lint-tree.py — Konsistenz-Check für die Node-Rechte in vault-tree.yaml (Epic #28 / T5).
+
+Validiert pro Node das `rights`-Block gegen die Baum-Hierarchie:
+  - clearance / default_visibility sind gültige visibility-Stufen
+  - default_visibility <= clearance      (man kann nichts erzeugen, was man nicht lesen darf)
+  - read  ⊆ {self} ∪ Vorfahren           (nur nach oben lesen — keine seitlichen Leaks)
+  - write ⊆ {self} ∪ Nachfahren          (nach oben schreiben = Promotion/T4, kein Default-Recht)
+  - parent / read / write referenzieren existierende Nodes
+  - clearance nimmt nach unten nicht ab   (sonst kann ein Kind den Eltern-Layer nicht lesen) [WARN]
+
+Graceful: ein fehlerhafter Node bricht den Lauf nie ab (OKF-Prinzip „tolerate, don't reject").
+
+Usage:
+    uv run lint-tree.py                  # $VAULT_ROOT/vault-tree.yaml (Fallback: Repo-Pfad)
+    uv run lint-tree.py --file PATH
+    uv run lint-tree.py --strict         # Exit 1 bei ERROR-Befunden
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+try:
+    from dotenv import load_dotenv
+    _vault = os.environ.get("VAULT_ROOT")
+    if _vault:
+        load_dotenv(Path(_vault) / ".env", override=False)
+    load_dotenv(Path(__file__).parent / ".env", override=False)
+except ImportError:
+    pass
+
+SCRIPT_ROOT = Path(__file__).parent
+VAULT_ROOT = Path(os.environ.get("VAULT_ROOT", str(SCRIPT_ROOT)))
+
+# Sichtbarkeits-Schichten, von offen (Index 0) nach restriktiv. Muss zu lint-links.py passen.
+VISIBILITY_LEVELS = ["public", "customer", "internal", "team", "personal"]
+
+
+def rank(level: str) -> int:
+    """Sensitivitäts-Rang einer visibility-Stufe (höher = restriktiver)."""
+    return VISIBILITY_LEVELS.index(level)
+
+
+def load_tree(path: Path) -> dict:
+    try:
+        import yaml
+    except ImportError:
+        print("ERROR: PyYAML nicht installiert: uv add pyyaml", file=sys.stderr)
+        sys.exit(2)
+    with path.open(encoding="utf-8") as f:
+        return yaml.safe_load(f) or {}
+
+
+def resolve_config(arg_file: str | None) -> Path:
+    if arg_file:
+        return Path(arg_file)
+    for cand in (VAULT_ROOT / "vault-tree.yaml", SCRIPT_ROOT / "vault-tree.yaml"):
+        if cand.is_file():
+            return cand
+    # Letzter Fallback: Beispiel (damit der Check ohne Setup demonstrierbar ist)
+    return SCRIPT_ROOT / "vault-tree.yaml.example"
+
+
+def ancestors(name: str, parent_of: dict[str, str | None]) -> set[str]:
+    """Alle Vorfahren von `name` (parent, grandparent, ...)."""
+    seen: set[str] = set()
+    cur = parent_of.get(name)
+    while cur and cur not in seen:
+        seen.add(cur)
+        cur = parent_of.get(cur)
+    return seen
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Konsistenz-Check für Node-Rechte in vault-tree.yaml")
+    parser.add_argument("--file", help="vault-tree.yaml (Default: $VAULT_ROOT, dann Repo-Pfad)")
+    parser.add_argument("--strict", action="store_true", help="Exit 1 bei ERROR-Befunden")
+    args = parser.parse_args()
+
+    config = resolve_config(args.file)
+    if not config.is_file():
+        print(f"ERROR: vault-tree.yaml nicht gefunden: {config}", file=sys.stderr)
+        return 2
+
+    data = load_tree(config)
+    nodes = data.get("tree", []) or []
+    names = {n.get("node") for n in nodes if isinstance(n, dict) and n.get("node")}
+    parent_of = {n["node"]: n.get("parent") for n in nodes if isinstance(n, dict) and n.get("node")}
+
+    errors: list[str] = []
+    warns: list[str] = []
+
+    for n in nodes:
+        # Graceful: kaputten Node-Eintrag überspringen
+        if not isinstance(n, dict) or not n.get("node"):
+            warns.append(f"Node-Eintrag ohne 'node'-Feld übersprungen: {n!r}")
+            continue
+        name = n["node"]
+
+        parent = n.get("parent")
+        if parent and parent not in names:
+            errors.append(f"{name}: parent '{parent}' existiert nicht im Baum")
+
+        rights = n.get("rights")
+        if not isinstance(rights, dict):
+            warns.append(f"{name}: kein 'rights'-Block — erbt nichts, nicht prüfbar")
+            continue
+
+        clearance = rights.get("clearance")
+        default_vis = rights.get("default_visibility")
+
+        if clearance not in VISIBILITY_LEVELS:
+            errors.append(f"{name}: ungültige clearance '{clearance}' "
+                          f"(erlaubt: {', '.join(VISIBILITY_LEVELS)})")
+        if default_vis not in VISIBILITY_LEVELS:
+            errors.append(f"{name}: ungültige default_visibility '{default_vis}' "
+                          f"(erlaubt: {', '.join(VISIBILITY_LEVELS)})")
+
+        if clearance in VISIBILITY_LEVELS and default_vis in VISIBILITY_LEVELS:
+            if rank(default_vis) > rank(clearance):
+                errors.append(f"{name}: default_visibility '{default_vis}' restriktiver als "
+                              f"clearance '{clearance}' — erzeugt unlesbare eigene Seiten")
+
+        anc = ancestors(name, parent_of)
+        allowed_read = {name} | anc
+        for r in rights.get("read", []) or []:
+            if r not in names:
+                errors.append(f"{name}: read-Ziel '{r}' existiert nicht im Baum")
+            elif r not in allowed_read:
+                errors.append(f"{name}: read-Ziel '{r}' ist weder self noch Vorfahr "
+                              f"(seitlicher Zugriff verboten)")
+
+        descendants = {m for m in names if name in ancestors(m, parent_of)}
+        allowed_write = {name} | descendants
+        for w in rights.get("write", []) or []:
+            if w not in names:
+                errors.append(f"{name}: write-Ziel '{w}' existiert nicht im Baum")
+            elif w not in allowed_write:
+                errors.append(f"{name}: write-Ziel '{w}' ist weder self noch Nachfahr "
+                              f"(Hochstufen = Promotion/T4, kein Default-Recht)")
+
+        # WARN: clearance darf nach unten nicht abnehmen, sonst Eltern-Layer unlesbar
+        if parent and parent in names and clearance in VISIBILITY_LEVELS:
+            p_rights = next((x.get("rights") for x in nodes
+                             if isinstance(x, dict) and x.get("node") == parent), None)
+            if isinstance(p_rights, dict) and p_rights.get("clearance") in VISIBILITY_LEVELS:
+                if rank(clearance) < rank(p_rights["clearance"]):
+                    warns.append(f"{name}: clearance '{clearance}' niedriger als Eltern "
+                                 f"'{parent}' ({p_rights['clearance']}) — kann Eltern-Layer nicht lesen")
+
+    # --- Report -----------------------------------------------------------
+    print(f"vault-tree: {config}  ({len(nodes)} Nodes)\n")
+
+    print(f"## ERROR ({len(errors)})")
+    for e in errors:
+        print(f"  ✗ {e}")
+    if not errors:
+        print("  (keine)")
+
+    print(f"\n## WARN ({len(warns)})")
+    for w in warns:
+        print(f"  ⚠ {w}")
+    if not warns:
+        print("  (keine)")
+
+    return 1 if (args.strict and errors) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/promote.py
+++ b/promote.py
@@ -1,0 +1,142 @@
+# /// script
+# dependencies = ["pyyaml", "python-dotenv"]
+# ///
+"""
+promote.py — Promotion-Planner für den Wissensbaum (Epic #28 / T4).
+
+Promotion = eine Seite aus einem eigenen/engeren Node in einen **Vorfahr-Node** heben und
+damit einem breiteren Publikum sichtbar machen (z.B. personal → team, team → company).
+
+Bewusst **kein Auto-Mover**: Hochstufen verbreitert die Sichtbarkeit und ist daher ein
+Review-pflichtiger Kurations-Schritt (T4-Gate). Dieses Tool *plant und validiert* die
+Promotion (permissibel? Ziel-Sichtbarkeit?), führt sie aber nicht selbst aus — der
+eigentliche Move + Review bleibt ein menschlicher Schritt.
+
+Regeln (gegen vault-tree.yaml geprüft):
+  - Ziel-Node muss ein Vorfahr der Quelle sein (nur nach oben).
+  - Ziel-Sichtbarkeit = default_visibility des Ziel-Nodes; muss das Publikum verbreitern
+    (rank(neu) <= rank(alt)), sonst ist es keine Promotion.
+
+Usage:
+    uv run promote.py --from personal-christian --to team-demand-ai --visibility personal
+    uv run promote.py --from personal-christian --to company --visibility team --file vault-tree.yaml
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+from access import VISIBILITY_LEVELS, normalize_visibility, rank
+
+try:
+    from dotenv import load_dotenv
+    _vault = os.environ.get("VAULT_ROOT")
+    if _vault:
+        load_dotenv(Path(_vault) / ".env", override=False)
+    load_dotenv(Path(__file__).parent / ".env", override=False)
+except ImportError:
+    pass
+
+SCRIPT_ROOT = Path(__file__).parent
+VAULT_ROOT = Path(os.environ.get("VAULT_ROOT", str(SCRIPT_ROOT)))
+
+
+@dataclass(frozen=True)
+class PromotionPlan:
+    allowed: bool
+    reason: str
+    source_node: str = ""
+    target_node: str = ""
+    old_visibility: str = ""
+    new_visibility: str = ""
+
+
+def ancestors(name: str, parent_of: dict[str, str | None]) -> set[str]:
+    seen: set[str] = set()
+    cur = parent_of.get(name)
+    while cur and cur not in seen:
+        seen.add(cur)
+        cur = parent_of.get(cur)
+    return seen
+
+
+def plan_promotion(source_node: str, source_visibility: str | None, target_node: str, *,
+                   parent_of: dict[str, str | None],
+                   rights_of: dict[str, dict]) -> PromotionPlan:
+    """Validiert eine geplante Promotion. allowed=True heißt *permissibel* — Review bleibt nötig."""
+    old_vis = normalize_visibility(source_visibility)
+
+    if target_node == source_node:
+        return PromotionPlan(False, "Ziel-Node ist die Quelle — keine Promotion")
+    if source_node not in parent_of:
+        return PromotionPlan(False, f"Quell-Node '{source_node}' existiert nicht im Baum")
+    if target_node not in parent_of:
+        return PromotionPlan(False, f"Ziel-Node '{target_node}' existiert nicht im Baum")
+    if target_node not in ancestors(source_node, parent_of):
+        return PromotionPlan(False, f"Ziel-Node '{target_node}' ist kein Vorfahr — "
+                                    f"Promotion nur nach oben")
+
+    tr = rights_of.get(target_node) or {}
+    new_vis = tr.get("default_visibility")
+    if new_vis not in VISIBILITY_LEVELS:
+        return PromotionPlan(False, f"Ziel-Node '{target_node}' hat keine gültige "
+                                    f"default_visibility")
+
+    if rank(new_vis) > rank(old_vis):
+        return PromotionPlan(False, f"verbreitert das Publikum nicht: Ziel '{new_vis}' "
+                                    f"restriktiver als Quelle '{old_vis}'")
+
+    return PromotionPlan(True, "permissibel — Review/Move erforderlich (T4-Gate)",
+                         source_node, target_node, old_vis, new_vis)
+
+
+def _load_tree(arg_file: str | None) -> dict:
+    if arg_file:
+        path = Path(arg_file)
+    else:
+        path = next((c for c in (VAULT_ROOT / "vault-tree.yaml", SCRIPT_ROOT / "vault-tree.yaml")
+                     if c.is_file()), SCRIPT_ROOT / "vault-tree.yaml.example")
+    try:
+        import yaml
+    except ImportError:
+        print("ERROR: PyYAML nicht installiert: uv add pyyaml", file=sys.stderr)
+        sys.exit(2)
+    with path.open(encoding="utf-8") as f:
+        return yaml.safe_load(f) or {}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Promotion-Planner für den Wissensbaum (T4)")
+    parser.add_argument("--from", dest="src", required=True, help="Quell-Node")
+    parser.add_argument("--to", dest="dst", required=True, help="Ziel-Node (muss Vorfahr sein)")
+    parser.add_argument("--visibility", help="aktuelle visibility der Seite (Default: personal)")
+    parser.add_argument("--file", help="vault-tree.yaml (Default: $VAULT_ROOT, dann Repo-Pfad)")
+    args = parser.parse_args()
+
+    data = _load_tree(args.file)
+    nodes = data.get("tree", []) or []
+    parent_of = {n["node"]: n.get("parent") for n in nodes if isinstance(n, dict) and n.get("node")}
+    rights_of = {n["node"]: n.get("rights") or {} for n in nodes
+                 if isinstance(n, dict) and n.get("node")}
+
+    plan = plan_promotion(args.src, args.visibility, args.dst,
+                          parent_of=parent_of, rights_of=rights_of)
+
+    if plan.allowed:
+        print(f"✓ Promotion permissibel: {plan.source_node} → {plan.target_node}")
+        print(f"  visibility: {plan.old_visibility} → {plan.new_visibility}")
+        print(f"  {plan.reason}")
+        print("  Nächster Schritt (manuell, mit Review): Seite in den Ziel-Node verschieben,")
+        print("  visibility-Frontmatter anpassen, Promotion in log.md vermerken.")
+        return 0
+
+    print(f"✗ Promotion abgelehnt: {plan.reason}")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/rebuild-code-wiki-index.py
+++ b/rebuild-code-wiki-index.py
@@ -287,29 +287,45 @@ def process_repo(repo_dir: Path, dry_run: bool) -> None:
     log.info("=" * 60)
 
     changed = 0
+    skipped = 0
+
+    def safe(fn, path: Path) -> bool:
+        """Graceful per-page processing: eine fehlerhafte Seite bricht den Lauf nie ab."""
+        nonlocal skipped
+        try:
+            return fn(path, dry_run)
+        except Exception as exc:  # noqa: BLE001 — bewusst breit: OKF-Prinzip "tolerate, don't reject"
+            skipped += 1
+            log.warning("SKIP   %s — %s: %s", path.name, type(exc).__name__, exc)
+            return False
 
     # Ticket-Seiten patchen
     tickets_dir = repo_dir / "tickets"
     if tickets_dir.exists():
         for f in sorted(tickets_dir.glob("*.md")):
-            if patch_ticket_page(f, dry_run):
+            if safe(patch_ticket_page, f):
                 changed += 1
 
     # Modul-Seiten patchen
     modules_dir = repo_dir / "modules"
     if modules_dir.exists():
         for f in sorted(modules_dir.glob("**/*.md")):
-            if patch_module_page(f, dry_run):
+            if safe(patch_module_page, f):
                 changed += 1
 
     # Changelog patchen
-    if patch_changelog(repo_dir / "changelog.md", dry_run):
+    if safe(patch_changelog, repo_dir / "changelog.md"):
         changed += 1
 
     # Index generieren
     write_repo_index(repo_dir, repo_name, dry_run)
 
-    log.info("Fertig: %d Seiten gepatcht%s", changed, "  [dry-run]" if dry_run else "")
+    log.info(
+        "Fertig: %d Seiten gepatcht, %d übersprungen%s",
+        changed,
+        skipped,
+        "  [dry-run]" if dry_run else "",
+    )
 
 
 def main() -> None:

--- a/test_access.py
+++ b/test_access.py
@@ -1,0 +1,103 @@
+"""test_access.py — Tests für den Retrieval-Filter (Epic #28 / T3).
+
+Schwerpunkt: kein Leakage höher klassifizierter Seiten an niedrigeres Clearance.
+Lauf: uv run --no-project python -m unittest test_access   (oder: python3 -m unittest test_access)
+"""
+
+import unittest
+
+from access import (
+    AgentProfile,
+    Page,
+    can_read,
+    can_write,
+    filter_readable,
+    load_agents,
+    normalize_clearance,
+    normalize_visibility,
+)
+
+
+def agent(clearance="internal", read=("company",), write="session"):
+    return AgentProfile(id="t", clearance=clearance, read_scope=frozenset(read), write_scope=write)
+
+
+class NormalizeTests(unittest.TestCase):
+    def test_missing_visibility_is_most_restrictive(self):
+        self.assertEqual(normalize_visibility(None), "personal")
+
+    def test_unknown_visibility_fails_closed_restrictive(self):
+        self.assertEqual(normalize_visibility("secret"), "personal")
+
+    def test_missing_clearance_is_least_access(self):
+        self.assertEqual(normalize_clearance(None), "public")
+
+    def test_unknown_clearance_fails_closed_least(self):
+        self.assertEqual(normalize_clearance("topsecret"), "public")
+
+    def test_values_are_case_and_quote_insensitive(self):
+        self.assertEqual(normalize_visibility('"Internal" '), "internal")
+
+
+class CanReadTests(unittest.TestCase):
+    def test_reads_equal_and_lower_sensitivity(self):
+        a = agent(clearance="internal")
+        self.assertTrue(can_read(Page("company", "internal"), a))
+        self.assertTrue(can_read(Page("company", "public"), a))
+
+    def test_denies_higher_sensitivity(self):
+        a = agent(clearance="internal")
+        self.assertFalse(can_read(Page("company", "team"), a))
+        self.assertFalse(can_read(Page("company", "personal"), a))
+
+    def test_denies_node_outside_read_scope(self):
+        # Sichtbarkeit ok, aber Node nicht im Scope → kein Zugriff (keine seitlichen Leaks)
+        a = agent(clearance="personal", read=("company",))
+        self.assertFalse(can_read(Page("team-other", "public"), a))
+
+    def test_unknown_page_visibility_is_hidden_unless_top_clearance(self):
+        page = Page("company", "bogus")           # → personal
+        self.assertFalse(can_read(page, agent(clearance="internal")))
+        self.assertTrue(can_read(page, agent(clearance="personal")))
+
+    def test_unknown_clearance_only_sees_public(self):
+        a = agent(clearance="bogus")              # → public
+        self.assertTrue(can_read(Page("company", "public"), a))
+        self.assertFalse(can_read(Page("company", "customer"), a))
+
+
+class FilterTests(unittest.TestCase):
+    def test_filter_excludes_leaks(self):
+        a = agent(clearance="customer", read=("company",))
+        pages = [
+            Page("company", "public", "p1"),
+            Page("company", "customer", "p2"),
+            Page("company", "internal", "p3"),   # zu sensibel
+            Page("team-x", "public", "p4"),       # falscher Node
+        ]
+        refs = {p.ref for p in filter_readable(pages, a)}
+        self.assertEqual(refs, {"p1", "p2"})
+
+
+class WriteTests(unittest.TestCase):
+    def test_write_only_to_own_scope(self):
+        a = agent(write="session")
+        self.assertTrue(can_write(a, "session"))
+        self.assertFalse(can_write(a, "company"))
+
+
+class LoadAgentsTests(unittest.TestCase):
+    def test_loads_profiles_and_fails_closed_on_bad_clearance(self):
+        data = {"agents": [
+            {"id": "prod", "clearance": "customer", "read_scope": ["company"], "write_scope": "session"},
+            {"id": "broken", "clearance": "nope", "read_scope": ["company"]},
+            {"description": "no id"},
+        ]}
+        agents = load_agents(data)
+        self.assertEqual(set(agents), {"prod", "broken"})
+        self.assertEqual(agents["broken"].clearance, "public")   # fail closed
+        self.assertEqual(agents["prod"].write_scope, "session")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_promote.py
+++ b/test_promote.py
@@ -1,0 +1,64 @@
+"""test_promote.py — Tests für den Promotion-Planner (Epic #28 / T4).
+
+Lauf: uv run --no-project python -m unittest test_promote
+"""
+
+import unittest
+
+from promote import plan_promotion
+
+# Baum: company → team-x → personal-a
+PARENT_OF = {"company": None, "team-x": "company", "personal-a": "team-x"}
+RIGHTS_OF = {
+    "company": {"clearance": "internal", "default_visibility": "internal"},
+    "team-x": {"clearance": "team", "default_visibility": "team"},
+    "personal-a": {"clearance": "personal", "default_visibility": "personal"},
+}
+
+
+def plan(src, vis, dst):
+    return plan_promotion(src, vis, dst, parent_of=PARENT_OF, rights_of=RIGHTS_OF)
+
+
+class PromotionTests(unittest.TestCase):
+    def test_personal_to_team_is_allowed_and_broadens(self):
+        p = plan("personal-a", "personal", "team-x")
+        self.assertTrue(p.allowed)
+        self.assertEqual((p.old_visibility, p.new_visibility), ("personal", "team"))
+
+    def test_team_to_company_is_allowed(self):
+        p = plan("team-x", "team", "company")
+        self.assertTrue(p.allowed)
+        self.assertEqual(p.new_visibility, "internal")
+
+    def test_downward_is_blocked(self):
+        # company → personal-a ist nicht "nach oben"
+        self.assertFalse(plan("company", "internal", "personal-a").allowed)
+
+    def test_lateral_or_nonancestor_is_blocked(self):
+        bad_parents = {"company": None, "team-x": "company", "team-y": "company"}
+        rights = {"team-y": {"clearance": "team", "default_visibility": "team"}, **RIGHTS_OF}
+        p = plan_promotion("team-x", "team", "team-y", parent_of=bad_parents, rights_of=rights)
+        self.assertFalse(p.allowed)
+
+    def test_same_node_is_blocked(self):
+        self.assertFalse(plan("team-x", "team", "team-x").allowed)
+
+    def test_missing_source_node_is_blocked(self):
+        self.assertFalse(plan("ghost", "personal", "company").allowed)
+
+    def test_target_more_restrictive_is_not_a_promotion(self):
+        # Quelle bereits internal; Ziel team (restriktiver) verbreitert das Publikum nicht
+        rights = {**RIGHTS_OF, "team-x": {"clearance": "team", "default_visibility": "team"}}
+        p = plan_promotion("personal-a", "internal", "team-x", parent_of=PARENT_OF, rights_of=rights)
+        self.assertFalse(p.allowed)
+
+    def test_unknown_source_visibility_defaults_restrictive(self):
+        # fehlende visibility → personal; personal → team ist eine gültige Promotion
+        p = plan("personal-a", None, "team-x")
+        self.assertTrue(p.allowed)
+        self.assertEqual(p.old_visibility, "personal")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vault-tree.yaml.example
+++ b/vault-tree.yaml.example
@@ -1,6 +1,15 @@
 # vault-tree.yaml.example
 # Kopieren nach vault-tree.yaml und anpassen.
 # vault-tree.yaml ist in .gitignore (enthält interne Repo-Namen).
+#
+# rights: (siehe CLAUDE.md › Sichtbarkeit & Wissensschichten, Epic #28 / T5)
+#   clearance          höchste (restriktivste) visibility-Stufe, die dieser Node LESEN darf
+#                      Leiter: public < customer < internal < team < personal
+#   default_visibility Default-visibility für hier erzeugte Seiten (muss <= clearance sein)
+#   read               Nodes, deren Inhalt gelesen werden darf — nur self + Vorfahren (nach oben)
+#   write              Nodes, in die geschrieben werden darf — nur self + Nachfahren (nach unten);
+#                      nach oben schreiben = Promotion (Review-Gate, T4), kein Default-Recht
+#   Prüfung: uv run lint-tree.py
 
 tree:
   - node: company
@@ -8,6 +17,11 @@ tree:
     type: company
     sync: sharepoint://knowledge-tree/_company
     ingest_service: github-actions   # wer schreibt auf dieser Ebene
+    rights:
+      clearance: internal
+      default_visibility: internal
+      read: [company]
+      write: [company]
     domains:                         # aktive Domain-Indizes
       - forecasting
       - supply-chain
@@ -21,6 +35,11 @@ tree:
     parent: company
     members: [christian, bernd, steffen]
     sync: sharepoint://knowledge-tree/_team-demand-ai
+    rights:
+      clearance: team
+      default_visibility: team
+      read: [team-demand-ai, company]   # self + Vorfahr
+      write: [team-demand-ai]
     repos:                           # GitHub-Repos für Code-Monitoring
       - owner: inform-group
         repo: demand-ai
@@ -37,6 +56,11 @@ tree:
     parent: team-demand-ai
     owner: christian
     sync: onedrive://personal/knowledge-personal/
+    rights:
+      clearance: personal
+      default_visibility: personal
+      read: [personal-christian, team-demand-ai, company]   # self + alle Vorfahren
+      write: [personal-christian]
 
 poll_interval_minutes: 15
 last_poll_state: .code-watch-state.json

--- a/vault-tree.yaml.example
+++ b/vault-tree.yaml.example
@@ -62,5 +62,28 @@ tree:
       read: [personal-christian, team-demand-ai, company]   # self + alle Vorfahren
       write: [personal-christian]
 
+# agents: (Epic #28 / T2) — Capability-Profile, die clearance + read/write-Scope an einen
+#   Agenten binden. Effektiver Lesezugriff auf eine Seite:
+#       rank(visibility) <= rank(clearance)  UND  node(seite) ∈ read_scope
+#   write_scope: existierender Node ODER 'session' (ephemerer Sandbox-Node, kein Persist im Baum).
+#   Prüfung: uv run lint-tree.py
+agents:
+  # Externer Produkt-Agent: in eine Software (z.B. ADD*ONE) eingebettet, bedient
+  # externe Software-User. Sieht nur public/customer; schreibt in einen ephemeren
+  # Session-Sandbox-Node, damit externer Input kein internes Gedächtnis vergiftet (T4).
+  - id: product-forecast-assistant
+    description: "In ADD*ONE eingebetteter Assistent für externe Software-User"
+    clearance: customer
+    read_scope: [company]
+    write_scope: session
+
+  # Interner Team-Copilot: liest den eigenen Team-Layer + Company (nach oben),
+  # schreibt Team-Wissen. clearance 'team' deckt public..team ab (inkl. company-internal).
+  - id: internal-demand-ai-copilot
+    description: "Interner Copilot für das Team demand-ai"
+    clearance: team
+    read_scope: [team-demand-ai, company]
+    write_scope: team-demand-ai
+
 poll_interval_minutes: 15
 last_poll_state: .code-watch-state.json

--- a/wiki-sync.py
+++ b/wiki-sync.py
@@ -130,11 +130,18 @@ def sync(dry_run: bool = False, verbose: bool = False) -> None:
         clone_archive(tmpdir)
 
         changed: list[str] = []
+        skipped = 0
         for archive_path, abs_path in sorted(files.items()):
             dest = Path(tmpdir) / archive_path
             dest.parent.mkdir(parents=True, exist_ok=True)
 
-            content = abs_path.read_bytes()
+            # Graceful: eine unlesbare Datei überspringen statt den ganzen Sync abzubrechen
+            try:
+                content = abs_path.read_bytes()
+            except OSError as exc:
+                skipped += 1
+                print(f"  ! SKIP {archive_path} — {type(exc).__name__}: {exc}", file=sys.stderr)
+                continue
             if dest.exists() and dest.read_bytes() == content:
                 if verbose:
                     print(f"  = {archive_path}")
@@ -151,7 +158,7 @@ def sync(dry_run: bool = False, verbose: bool = False) -> None:
             print("Keine Änderungen — nichts zu pushen.")
             return
 
-        print(f"\n{len(changed)} Datei(en) geändert.")
+        print(f"\n{len(changed)} Datei(en) geändert." + (f" ({skipped} übersprungen)" if skipped else ""))
 
         if dry_run:
             return
@@ -197,7 +204,11 @@ def pull(dry_run: bool = False, verbose: bool = False) -> None:
         conflicts: list[str] = []
         for archive_path, src in sorted(archive_files):
             dest = VAULT_ROOT / archive_path
-            content = src.read_bytes()
+            try:
+                content = src.read_bytes()
+            except OSError as exc:
+                print(f"  ! SKIP {archive_path} — {type(exc).__name__}: {exc}", file=sys.stderr)
+                continue
 
             if dest.exists():
                 if dest.read_bytes() == content:


### PR DESCRIPTION
Setzt **Epic #28** komplett um (T1–T5) und zwei vorgelagerte OKF-inspirierte Verbesserungen (a/b). Inspiriert vom [Open Knowledge Format](https://github.com/GoogleCloudPlatform/knowledge-catalog/tree/main/okf) — wir erweitern es OKF-kompatibel (Custom-Keys, graceful degradation).

## Vorarbeit (a/b)
- **Graceful degradation:** `rebuild-code-wiki-index.py` und `wiki-sync.py` überspringen eine fehlerhafte Einzelseite (Warnung + weiter) statt den ganzen Lauf abzubrechen. Prinzip in `CLAUDE.md` verankert.
- **Portable Links + Checker:** `lint-links.py` löst `[[wikilinks]]` *und* bundle-relative `/pfad.md`-Links auf, meldet Broken Links & Waisen, toleriert kaputte Ziele.

## Epic #28 — Wissensschichten & Agenten-Gedächtnis
- **T1 (#29) — `visibility`-Frontmatter:** Schicht-Klassifizierung (`public < customer < internal < team < personal`) in den kuratierten Schemas; Default = restriktivste Stufe (safe by default); `lint-links.py` validiert.
- **T5 (#33) — Node-Rechte:** `rights`-Block pro Node in `vault-tree.yaml` (clearance/default_visibility/read/write); `lint-tree.py` prüft die Hierarchie (Read nur nach oben, Write nur nach unten, clearance-Monotonie).
- **T2 (#30) — Agenten-Capabilities:** `agents:`-Profile (clearance + read_scope + write_scope), zwei Referenz-Profile (Produkt-Agent → `session`-Sandbox; interner Team-Copilot). `lint-tree.py` validiert.
- **T3 (#31) — Durchsetzung:** `access.py` — wiederverwendbarer Retrieval-Filter (`can_read`/`filter_readable`), angewandt *vor* der Kontextbefüllung. **Fail closed** (unbekannte visibility → verbergen, unbekannte clearance → public). Single source of truth der visibility-Leiter; beide Linter importieren sie. 13 Tests gegen Leakage.
- **T4 (#32) — Memory & Promotion:** Schreibzonen (`session` vs. persistenter Node), Memory-Schichten (episodisch=`log.md`, semantisch=`concepts`/`entities`), und `promote.py` — ein Promotion-*Planner* mit Review-Gate (kein Auto-Move). 8 Tests.

## Tests
`uv run --no-project python -m unittest test_access test_promote` → **21 Tests grün.** `lint-links.py` und `lint-tree.py` smoke-getestet (Beispiel clean, Broken-Cases gefangen).

## Hinweise für Review
- `access.py` ist eine **Sicherheits-Boundary** — Hauptfokus: kein Leakage, fail closed.
- Reine Klassifizierung in Frontmatter ist keine Grenze; Durchsetzung gehört in den Retrieval-Layer (`access.py`) — so umgesetzt.
- Keine Daten-Migration bestehender Vault-Seiten (bewusst außerhalb des Scopes).

Closes #28, #29, #30, #31, #32, #33

https://claude.ai/code/session_014zKRyTbFBTLzVbzaAMyXv5

---
_Generated by [Claude Code](https://claude.ai/code/session_014zKRyTbFBTLzVbzaAMyXv5)_