### PR TITLE
pkwiki MCP-Server: Wiki als Agenten-Gedächtnis (Read + Write)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,10 @@ VAULT_ROOT=C:\Users\<user>\OneDrive - INFORM GmbH\knowledge-wiki
 WIKI_ARCHIVE_PAT=<personal-access-token>
 WIKI_ARCHIVE_REPO=schlinge2000/knowledge-wiki-archive
 
+# MCP-Server (pkwiki-mcp.py): Agenten-Identität aus vault-tree.yaml (agents:)
+# Bestimmt clearance + read/write-Scope des Servers. Beispiel-Profile siehe vault-tree.yaml.example
+PKWIKI_AGENT_ID=internal-demand-ai-copilot
+
 # SharePoint (für zentralen Ingest-Service — optional, Phase 3)
 # SHAREPOINT_TENANT_ID=<tenant-id>
 # SHAREPOINT_CLIENT_ID=<app-registration-client-id>

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ output/*
 # Temporäre Dateien
 *.tmp
 ~$*
+
+# Ephemerer MCP-Session-Sandbox (write_scope: session) — nie committen
+.sessions/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,6 +149,7 @@ uv run code-watch.py --loop     # Daemon-Modus (nur für Debugging)
 | `lint-links.py` | Graceful Link-Checker: löst `[[wikilinks]]` + bundle-relative Links auf, meldet Broken Links & Waisen; prüft `visibility` |
 | `lint-tree.py` | Konsistenz-Check der Node-Rechte in `vault-tree.yaml` (read/write-Zonen vs. Hierarchie) |
 | `access.py` | Retrieval-Filter-Bibliothek: `can_read`/`filter_readable` (visibility-Durchsetzung, fail closed) — *single source of truth* der visibility-Leiter |
+| `pkwiki-mcp.py` / `pkwiki_server.py` | MCP-Server (stdio): stellt das Wiki als Agenten-Gedächtnis bereit, Zugriffe durch `access.py` gegated |
 | `promote.py` | Promotion-Planner: validiert Hochstufen einer Seite in einen Vorfahr-Node (Review-Gate, kein Auto-Move) |
 | `test-connection.py` | Smoke-Test der Azure-OpenAI- und GitHub-Verbindung |
 
@@ -419,6 +420,28 @@ visible = filter_readable(candidate_pages, agent)   # Gate vor dem Kontextfenste
   ungültige Agenten-`clearance` → `public` (geringster Zugriff). Unbekanntes leakt nie.
 - Tests: `uv run --no-project python -m unittest test_access` (Fokus: kein Leakage).
 - Reiner Stdlib-Code → von jedem Retrieval-Layer (Produkt-Agent, MCP-Server) importierbar.
+
+### MCP-Server (`pkwiki-mcp.py`)
+
+Stellt das Wiki als **Agenten-Gedächtnis** über MCP (stdio) bereit. Der Server *ist* die Sicht
+genau eines Agenten: er lädt dessen `AgentProfile` aus `vault-tree.yaml` (`PKWIKI_AGENT_ID`)
+und setzt alle Zugriffe über `access.py` durch — kein Tool umgeht den Filter.
+
+```bash
+PKWIKI_AGENT_ID=internal-demand-ai-copilot VAULT_ROOT=/pfad uv run pkwiki-mcp.py
+```
+
+| Tool | Wirkung |
+|------|---------|
+| `search_wiki(query)` | Titel-/Volltextsuche — nur lesbare Treffer |
+| `read_page(ref)` | Seiteninhalt (`ref` = `node:pfad.md`), nur wenn `can_read` |
+| `list_index()` | lesbare Seiten nach Node |
+| `remember(text)` | episodisch: an `log.md` im `write_scope` anhängen |
+| `save_note(title, content)` | semantisch: Konzeptseite im `write_scope` (`visibility` = `default_visibility` des Nodes) |
+
+- **Read** gefiltert durch `filter_readable`; **Write** nur in `write_scope` (`can_write`).
+- `write_scope: session` → ephemerer Sandbox unter `.sessions/<agent>/` (gitignored, kein Persist).
+- Kernlogik in `pkwiki_server.py` (ohne `mcp`/`yaml`-Import → testbar); Tests: `test_mcp.py`.
 
 ### Agenten-Gedächtnis & Promotion
 

--- a/pkwiki-mcp.py
+++ b/pkwiki-mcp.py
@@ -1,0 +1,102 @@
+# /// script
+# dependencies = ["mcp", "pyyaml", "python-dotenv"]
+# ///
+"""pkwiki-mcp.py — MCP-Server, der das Wiki als Agenten-Gedächtnis bereitstellt.
+
+Der Server *ist* die Sicht genau eines Agenten: er lädt dessen AgentProfile aus
+vault-tree.yaml (via PKWIKI_AGENT_ID) und setzt Lese-/Schreibrechte über access.py
+durch — kein Tool umgeht den Filter.
+
+Tools:
+    search_wiki(query)         — Volltext-/Titelsuche über lesbare Seiten
+    read_page(ref)             — Seiteninhalt (nur wenn lesbar)
+    list_index()               — lesbare Seiten nach Node
+    remember(text)             — episodisch: an log.md im write_scope anhängen
+    save_note(title, content)  — semantisch: Konzeptseite im write_scope anlegen
+
+Start (stdio):
+    PKWIKI_AGENT_ID=internal-demand-ai-copilot VAULT_ROOT=/pfad uv run pkwiki-mcp.py
+
+Kernlogik + Tests: pkwiki_server.py / test_mcp.py (ohne mcp-Dependency lauffähig).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+try:
+    from dotenv import load_dotenv
+    _vault = os.environ.get("VAULT_ROOT")
+    if _vault:
+        load_dotenv(Path(_vault) / ".env", override=False)
+    load_dotenv(Path(__file__).parent / ".env", override=False)
+except ImportError:
+    pass
+
+import pkwiki_server as core
+
+SCRIPT_ROOT = Path(__file__).parent
+VAULT_ROOT = Path(os.environ.get("VAULT_ROOT", str(SCRIPT_ROOT)))
+AGENT_ID = os.environ.get("PKWIKI_AGENT_ID", "")
+
+
+def _load_tree() -> dict:
+    import yaml
+    for cand in (VAULT_ROOT / "vault-tree.yaml", SCRIPT_ROOT / "vault-tree.yaml",
+                 SCRIPT_ROOT / "vault-tree.yaml.example"):
+        if cand.is_file():
+            with cand.open(encoding="utf-8") as f:
+                return yaml.safe_load(f) or {}
+    return {}
+
+
+def main() -> None:
+    if not AGENT_ID:
+        print("ERROR: PKWIKI_AGENT_ID nicht gesetzt — Server kennt keine Agenten-Identität.",
+              file=sys.stderr)
+        sys.exit(2)
+
+    try:
+        from mcp.server.fastmcp import FastMCP
+    except ImportError:
+        print("ERROR: 'mcp' nicht installiert — `uv run pkwiki-mcp.py` (inline deps) verwenden.",
+              file=sys.stderr)
+        sys.exit(2)
+
+    tree = _load_tree()
+    agent = core.get_agent(tree, AGENT_ID)
+
+    mcp = FastMCP("pkwiki")
+
+    @mcp.tool()
+    def search_wiki(query: str, limit: int = 20) -> list[dict]:
+        """Durchsucht das Wiki (Titel + Volltext) und liefert nur lesbare Treffer."""
+        return core.search(VAULT_ROOT, tree, agent, query, limit)
+
+    @mcp.tool()
+    def read_page(ref: str) -> dict:
+        """Liefert den Inhalt einer Seite (ref = 'node:pfad.md'), wenn lesbar."""
+        return core.read_page(VAULT_ROOT, tree, agent, ref)
+
+    @mcp.tool()
+    def list_index() -> list[dict]:
+        """Listet alle für diesen Agenten lesbaren Seiten (nach Node)."""
+        return core.list_index(VAULT_ROOT, tree, agent)
+
+    @mcp.tool()
+    def remember(text: str) -> dict:
+        """Hängt einen Eintrag an das log.md des write_scope (episodisches Gedächtnis)."""
+        return core.remember(VAULT_ROOT, tree, agent, text)
+
+    @mcp.tool()
+    def save_note(title: str, content: str) -> dict:
+        """Legt eine Konzeptseite im write_scope an (semantisches Gedächtnis)."""
+        return core.save_note(VAULT_ROOT, tree, agent, title, content)
+
+    mcp.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/pkwiki_server.py
+++ b/pkwiki_server.py
@@ -1,0 +1,242 @@
+"""pkwiki_server.py — Kernlogik des pkwiki-MCP-Servers (Epic #28, Folge-Ticket).
+
+Reiner, testbarer Kern: lädt eine Agenten-Identität (AgentProfile aus vault-tree.yaml)
+und stellt Lese-/Schreiboperationen über das Wiki bereit, die durch `access.py`
+durchgesetzt werden:
+
+    Lesen  : nur Seiten mit  rank(visibility) <= rank(clearance)  UND  node ∈ read_scope
+    Schreiben: nur in den write_scope des Agenten (Node ODER 'session'-Sandbox)
+
+Bewusst ohne `mcp`/`yaml`-Import — die werden im dünnen Entrypoint `pkwiki-mcp.py`
+geladen. So laufen die Tests (test_mcp.py) ohne Netzwerk/externe Deps auf stdlib.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+from access import (
+    AgentProfile,
+    Page,
+    SESSION,
+    can_read,
+    can_write,
+    filter_readable,
+    load_agents,
+    normalize_visibility,
+)
+
+FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---", re.DOTALL)
+VISIBILITY_RE = re.compile(r"^visibility:\s*(.+)$", re.MULTILINE)
+TITLE_RE = re.compile(r"^title:\s*(.+)$", re.MULTILINE)
+
+
+def _slugify(name: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-") or "note"
+
+
+@dataclass(frozen=True)
+class WikiPage:
+    """Eine Wiki-Seite samt Node + Klassifizierung (für Retrieval + Reporting)."""
+    node: str
+    rel: str          # Pfad relativ zum wiki/-Root des Nodes (z.B. "concepts/foo.md")
+    abs_path: Path
+    visibility: str
+    title: str
+
+    @property
+    def ref(self) -> str:
+        """Stabile Referenz über Node-Grenzen: 'node:concepts/foo.md'."""
+        return f"{self.node}:{self.rel}"
+
+    def as_access_page(self) -> Page:
+        return Page(node=self.node, visibility=self.visibility, ref=self.ref)
+
+
+# ---------------------------------------------------------------------------
+# Konfiguration / Baum
+# ---------------------------------------------------------------------------
+
+def node_wiki_dirs(vault_root: Path, tree: dict) -> dict[str, Path]:
+    """node-name → dessen wiki/-Verzeichnis (mirror der wiki-sync.py-Konvention)."""
+    out: dict[str, Path] = {}
+    for n in tree.get("tree", []) or []:
+        if isinstance(n, dict) and n.get("node") and n.get("path"):
+            out[n["node"]] = vault_root / n["path"] / "wiki"
+    return out
+
+
+def node_default_visibility(tree: dict, node: str) -> str:
+    """default_visibility eines Nodes (für neu erzeugte Seiten); Fallback restriktiv."""
+    for n in tree.get("tree", []) or []:
+        if isinstance(n, dict) and n.get("node") == node:
+            rights = n.get("rights")
+            if isinstance(rights, dict):
+                return normalize_visibility(rights.get("default_visibility"))
+    return normalize_visibility(None)   # personal
+
+
+def get_agent(tree: dict, agent_id: str) -> AgentProfile:
+    """AgentProfile aus dem Baum laden. Unbekannte id → fail closed (public/leerer Scope)."""
+    agents = load_agents(tree)
+    if agent_id in agents:
+        return agents[agent_id]
+    return AgentProfile(id=agent_id, clearance="public",
+                        read_scope=frozenset(), write_scope=SESSION)
+
+
+# ---------------------------------------------------------------------------
+# Seiten einsammeln
+# ---------------------------------------------------------------------------
+
+def _parse_page(node: str, wiki_dir: Path, f: Path) -> WikiPage | None:
+    try:
+        text = f.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None   # graceful: unlesbare Seite überspringen
+    fm = FRONTMATTER_RE.search(text)
+    block = fm.group(1) if fm else ""
+    vm = VISIBILITY_RE.search(block)
+    tm = TITLE_RE.search(block)
+    visibility = normalize_visibility(vm.group(1) if vm else None)
+    title = (tm.group(1).strip().strip('"').strip("'") if tm else f.stem)
+    return WikiPage(
+        node=node,
+        rel=f.relative_to(wiki_dir).as_posix(),
+        abs_path=f,
+        visibility=visibility,
+        title=title,
+    )
+
+
+def collect_pages(vault_root: Path, tree: dict) -> list[WikiPage]:
+    """Alle Wiki-Seiten über alle Nodes — unabhängig von Sichtbarkeit (Filter kommt später)."""
+    pages: list[WikiPage] = []
+    for node, wiki_dir in node_wiki_dirs(vault_root, tree).items():
+        if not wiki_dir.exists():
+            continue
+        for f in sorted(wiki_dir.rglob("*.md")):
+            page = _parse_page(node, wiki_dir, f)
+            if page is not None:
+                pages.append(page)
+    return pages
+
+
+def readable_pages(vault_root: Path, tree: dict, agent: AgentProfile) -> list[WikiPage]:
+    """Nur die für den Agenten lesbaren Seiten (Gate via access.filter_readable)."""
+    pages = collect_pages(vault_root, tree)
+    allowed_refs = {p.ref for p in filter_readable([wp.as_access_page() for wp in pages], agent)}
+    return [wp for wp in pages if wp.ref in allowed_refs]
+
+
+# ---------------------------------------------------------------------------
+# Lese-Operationen (durch access.py gegated)
+# ---------------------------------------------------------------------------
+
+def search(vault_root: Path, tree: dict, agent: AgentProfile, query: str,
+           limit: int = 20) -> list[dict]:
+    """Volltext-/Titel-Substring-Suche über die lesbaren Seiten."""
+    q = query.lower().strip()
+    hits: list[dict] = []
+    for wp in readable_pages(vault_root, tree, agent):
+        try:
+            body = wp.abs_path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        if not q or q in wp.title.lower() or q in body.lower() or q in wp.rel.lower():
+            hits.append({
+                "ref": wp.ref,
+                "title": wp.title,
+                "node": wp.node,
+                "visibility": wp.visibility,
+                "snippet": _snippet(body),
+            })
+        if len(hits) >= limit:
+            break
+    return hits
+
+
+def _snippet(text: str, length: int = 160) -> str:
+    body = FRONTMATTER_RE.sub("", text, count=1).strip()
+    body = re.sub(r"\s+", " ", body)
+    return body[:length] + ("…" if len(body) > length else "")
+
+
+def read_page(vault_root: Path, tree: dict, agent: AgentProfile, ref: str) -> dict:
+    """Inhalt einer Seite — nur wenn der Agent sie lesen darf. Fail closed bei Unbekanntem."""
+    for wp in collect_pages(vault_root, tree):
+        if wp.ref == ref:
+            if can_read(wp.as_access_page(), agent):
+                try:
+                    content = wp.abs_path.read_text(encoding="utf-8")
+                except (OSError, UnicodeDecodeError) as exc:
+                    return {"ok": False, "error": f"unlesbar: {exc}"}
+                return {"ok": True, "ref": ref, "title": wp.title,
+                        "visibility": wp.visibility, "content": content}
+            return {"ok": False, "error": "kein Lesezugriff (visibility/scope)"}
+    return {"ok": False, "error": f"Seite nicht gefunden: {ref}"}
+
+
+def list_index(vault_root: Path, tree: dict, agent: AgentProfile) -> list[dict]:
+    """Lesbare Seiten nach Node gruppiert (kompakter Index)."""
+    out: list[dict] = []
+    for wp in readable_pages(vault_root, tree, agent):
+        out.append({"ref": wp.ref, "title": wp.title,
+                    "node": wp.node, "visibility": wp.visibility})
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Schreib-Operationen (nur in write_scope; 'session' = ephemerer Sandbox)
+# ---------------------------------------------------------------------------
+
+def _write_target(vault_root: Path, tree: dict, agent: AgentProfile) -> tuple[str, Path, str]:
+    """(node-label, wiki-dir, visibility) für Schreibvorgänge des Agenten."""
+    if agent.write_scope == SESSION:
+        # ephemerer, nicht-synchronisierter Sandbox-Node
+        return SESSION, vault_root / ".sessions" / agent.id / "wiki", "personal"
+    wiki_dir = node_wiki_dirs(vault_root, tree).get(agent.write_scope)
+    if wiki_dir is None:
+        # write_scope zeigt auf unbekannten Node → fail closed: in Session ausweichen
+        return SESSION, vault_root / ".sessions" / agent.id / "wiki", "personal"
+    return agent.write_scope, wiki_dir, node_default_visibility(tree, agent.write_scope)
+
+
+def remember(vault_root: Path, tree: dict, agent: AgentProfile, text: str) -> dict:
+    """Episodisches Gedächtnis: Eintrag an log.md im write_scope anhängen."""
+    if not can_write(agent, agent.write_scope):
+        return {"ok": False, "error": "kein Schreibzugriff"}
+    label, wiki_dir, _ = _write_target(vault_root, tree, agent)
+    wiki_dir.mkdir(parents=True, exist_ok=True)
+    log = wiki_dir / "log.md"
+    ts = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M")
+    entry = f"\n## {ts} — AGENT {agent.id}\n{text.strip()}\n"
+    with log.open("a", encoding="utf-8") as fh:
+        fh.write(entry)
+    return {"ok": True, "node": label, "path": str(log)}
+
+
+def save_note(vault_root: Path, tree: dict, agent: AgentProfile,
+              title: str, content: str) -> dict:
+    """Semantisches Gedächtnis: Konzeptseite im write_scope anlegen/überschreiben.
+
+    visibility = default_visibility des Ziel-Nodes (Session → personal).
+    """
+    if not can_write(agent, agent.write_scope):
+        return {"ok": False, "error": "kein Schreibzugriff"}
+    label, wiki_dir, visibility = _write_target(vault_root, tree, agent)
+    concepts = wiki_dir / "concepts"
+    concepts.mkdir(parents=True, exist_ok=True)
+    slug = _slugify(title)
+    path = concepts / f"{slug}.md"
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    page = (
+        f"---\ntitle: {title}\ntype: concept\nvisibility: {visibility}\n"
+        f"last_updated: {today}\n---\n\n{content.strip()}\n"
+    )
+    path.write_text(page, encoding="utf-8")
+    return {"ok": True, "node": label, "ref": f"{label}:concepts/{slug}.md",
+            "visibility": visibility, "path": str(path)}

--- a/test_mcp.py
+++ b/test_mcp.py
@@ -1,0 +1,118 @@
+"""test_mcp.py — Tests für die pkwiki-MCP-Kernlogik (pkwiki_server.py).
+
+Schwerpunkt: der Server leakt nichts über die Agenten-clearance/read_scope hinaus
+und schreibt nur in den write_scope. Lauf:
+    python3 -m unittest test_mcp     (kein mcp/yaml nötig)
+"""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import pkwiki_server as core
+from access import AgentProfile, SESSION
+
+
+def make_vault() -> Path:
+    """Temporäres Vault mit zwei Nodes (company, team-x) und gemischter visibility."""
+    root = Path(tempfile.mkdtemp())
+
+    def page(node_path, rel, visibility, title, body="Inhalt."):
+        p = root / node_path / "wiki" / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(
+            f"---\ntitle: {title}\ntype: concept\nvisibility: {visibility}\n---\n\n{body}\n",
+            encoding="utf-8",
+        )
+
+    page("_company", "concepts/public-thing.md", "public", "Public Thing")
+    page("_company", "concepts/internal-thing.md", "internal", "Internal Thing")
+    page("_team-x", "concepts/team-secret.md", "team", "Team Secret")
+    return root
+
+
+TREE = {
+    "tree": [
+        {"node": "company", "path": "_company/",
+         "rights": {"clearance": "internal", "default_visibility": "internal"}},
+        {"node": "team-x", "path": "_team-x/",
+         "rights": {"clearance": "team", "default_visibility": "team"}},
+    ]
+}
+
+
+def agent(clearance, read, write=SESSION):
+    return AgentProfile(id="a", clearance=clearance,
+                        read_scope=frozenset(read), write_scope=write)
+
+
+class ReadGatingTests(unittest.TestCase):
+    def setUp(self):
+        self.vault = make_vault()
+
+    def test_customer_agent_sees_only_public_in_company(self):
+        a = agent("customer", ["company"])
+        refs = {h["ref"] for h in core.list_index(self.vault, TREE, a)}
+        self.assertEqual(refs, {"company:concepts/public-thing.md"})
+
+    def test_internal_agent_sees_public_and_internal(self):
+        a = agent("internal", ["company"])
+        refs = {h["ref"] for h in core.list_index(self.vault, TREE, a)}
+        self.assertEqual(refs, {"company:concepts/public-thing.md",
+                                "company:concepts/internal-thing.md"})
+
+    def test_node_outside_read_scope_is_invisible(self):
+        # clearance reicht für team, aber team-x ist nicht im read_scope
+        a = agent("team", ["company"])
+        refs = {h["ref"] for h in core.list_index(self.vault, TREE, a)}
+        self.assertNotIn("team-x:concepts/team-secret.md", refs)
+
+    def test_read_page_denies_too_sensitive(self):
+        a = agent("internal", ["company"])
+        res = core.read_page(self.vault, TREE, a, "company:concepts/internal-thing.md")
+        self.assertTrue(res["ok"])
+        # team-secret nicht im scope → verweigert
+        a2 = agent("internal", ["company"])
+        res2 = core.read_page(self.vault, TREE, a2, "team-x:concepts/team-secret.md")
+        self.assertFalse(res2["ok"])
+
+    def test_search_only_returns_readable(self):
+        a = agent("customer", ["company"])
+        hits = core.search(self.vault, TREE, a, "thing")
+        refs = {h["ref"] for h in hits}
+        self.assertEqual(refs, {"company:concepts/public-thing.md"})
+
+
+class WriteTests(unittest.TestCase):
+    def setUp(self):
+        self.vault = make_vault()
+
+    def test_session_write_goes_to_ephemeral_sandbox(self):
+        a = agent("customer", ["company"], write=SESSION)
+        res = core.save_note(self.vault, TREE, a, "My Note", "body")
+        self.assertTrue(res["ok"])
+        self.assertEqual(res["node"], SESSION)
+        self.assertEqual(res["visibility"], "personal")   # session → restriktiv
+        self.assertTrue((self.vault / ".sessions" / "a" / "wiki").exists())
+
+    def test_persistent_write_uses_node_default_visibility(self):
+        a = agent("team", ["team-x", "company"], write="team-x")
+        res = core.save_note(self.vault, TREE, a, "Team Note", "body")
+        self.assertTrue(res["ok"])
+        self.assertEqual(res["node"], "team-x")
+        self.assertEqual(res["visibility"], "team")
+
+    def test_remember_appends_log(self):
+        a = agent("team", ["team-x"], write="team-x")
+        core.remember(self.vault, TREE, a, "etwas passiert")
+        log = self.vault / "_team-x" / "wiki" / "log.md"
+        self.assertIn("etwas passiert", log.read_text(encoding="utf-8"))
+
+    def test_unknown_write_scope_falls_back_to_session(self):
+        a = agent("internal", ["company"], write="ghost-node")
+        res = core.save_note(self.vault, TREE, a, "X", "y")
+        self.assertEqual(res["node"], SESSION)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Stellt das Wiki über einen **MCP-Server** (stdio) als Agenten-Langzeitgedächtnis bereit — der erste echte Consumer des Sichtbarkeitsmodells aus Epic #28.

> **Stacked PR:** Basis ist `claude/affectionate-fermat-1uz9nw` (PR #34), weil der Server `access.py` (T3) importiert. Nach Merge von #34 auf `main` retargeten.

## Was drin ist
- **`pkwiki-mcp.py`** — dünner FastMCP-Entrypoint. Server = Sicht **eines** Agenten (`PKWIKI_AGENT_ID` → `AgentProfile` aus `vault-tree.yaml`).
- **`pkwiki_server.py`** — testbarer Kern (ohne `mcp`/`yaml`-Import). Alle Zugriffe durch `access.py` gegated.
- **`test_mcp.py`** — 9 Tests (Read-Gating + Write-Scoping). Gesamtsuite: **30 Tests grün**.

## Tools
| Tool | Wirkung | Gate |
|------|---------|------|
| `search_wiki(query)` | Titel-/Volltextsuche | `filter_readable` |
| `read_page(ref)` | Seiteninhalt (`node:pfad.md`) | `can_read` |
| `list_index()` | lesbare Seiten nach Node | `filter_readable` |
| `remember(text)` | episodisch → `log.md` | `can_write` |
| `save_note(title, content)` | semantisch → `concepts/` | `can_write` |

## Sicherheit / Design
- **Read** nie über `clearance`/`read_scope` hinaus; **fail closed** (erbt das Verhalten von `access.py`).
- **Write** nur in `write_scope`. `session` → ephemerer Sandbox `.sessions/<agent>/` (gitignored, kein Persist) — externer Input vergiftet kein persistentes Gedächtnis.
- Neue Seiten tragen `visibility` = `default_visibility` des Ziel-Nodes → schließt einen Teil der Producer-Lücke (#37).

## Tests
```
uv run --no-project python -m unittest test_access test_promote test_mcp   # 30 grün
```
Live-MCP-Protokoll (stdio) ist hier nicht automatisiert getestet — die Tool-Funktionen sind dünne Wrapper um den getesteten Kern.

Closes #35

https://claude.ai/code/session_014zKRyTbFBTLzVbzaAMyXv5

---
_Generated by [Claude Code](https://claude.ai/code/session_014zKRyTbFBTLzVbzaAMyXv5)_