### PR TITLE
fix+feat: Windows-UTF-8, Clippings-Pfad & reorganise-Cache (Robustheit der neuen Skripte)

### DIFF
--- a/clippings-ingest.py
+++ b/clippings-ingest.py
@@ -31,12 +31,16 @@ import argparse
 import io
 import json
 import logging
+import os
 import subprocess
 import sys
 from pathlib import Path
 
 WIKI_ROOT = Path(__file__).parent
-DEFAULT_CLIPPINGS_DIR = WIKI_ROOT / "Clippings"
+# Der Obsidian Web Clipper schreibt in den Vault-Root (= $VAULT_ROOT, OneDrive),
+# nicht ins Repo. Default folgt dem Vault; Fallback auf Repo-Dir, wenn nicht gesetzt.
+VAULT_ROOT = Path(os.environ.get("VAULT_ROOT", str(WIKI_ROOT)))
+DEFAULT_CLIPPINGS_DIR = VAULT_ROOT / "Clippings"
 DEFAULT_STATE_FILE = WIKI_ROOT / ".clippings-state.json"
 
 sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8", errors="replace")

--- a/lint-links.py
+++ b/lint-links.py
@@ -42,6 +42,13 @@ try:
 except ImportError:
     pass
 
+# Windows-Konsole ist per Default cp1252 — Unicode-Report (✗, ○, →) würde crashen.
+for _stream in (sys.stdout, sys.stderr):
+    try:
+        _stream.reconfigure(encoding="utf-8")
+    except (AttributeError, ValueError):
+        pass
+
 SCRIPT_ROOT = Path(__file__).parent
 VAULT_ROOT = Path(os.environ.get("VAULT_ROOT", str(SCRIPT_ROOT)))
 

--- a/lint-tree.py
+++ b/lint-tree.py
@@ -38,6 +38,13 @@ except ImportError:
 
 from access import VISIBILITY_LEVELS, rank  # Single source of truth (T3)
 
+# Windows-Konsole ist per Default cp1252 — Unicode-Report (✗, ⚠) würde crashen.
+for _stream in (sys.stdout, sys.stderr):
+    try:
+        _stream.reconfigure(encoding="utf-8")
+    except (AttributeError, ValueError):
+        pass
+
 SCRIPT_ROOT = Path(__file__).parent
 VAULT_ROOT = Path(os.environ.get("VAULT_ROOT", str(SCRIPT_ROOT)))
 

--- a/promote.py
+++ b/promote.py
@@ -32,6 +32,13 @@ from pathlib import Path
 
 from access import VISIBILITY_LEVELS, normalize_visibility, rank
 
+# Windows-Konsole ist per Default cp1252 — Unicode-Report (✓, ✗) würde crashen.
+for _stream in (sys.stdout, sys.stderr):
+    try:
+        _stream.reconfigure(encoding="utf-8")
+    except (AttributeError, ValueError):
+        pass
+
 try:
     from dotenv import load_dotenv
     _vault = os.environ.get("VAULT_ROOT")

--- a/reorganise.py
+++ b/reorganise.py
@@ -53,6 +53,13 @@ except ImportError:
 # access.py = single source of truth der visibility-Leiter (reine stdlib, testbar)
 from access import VISIBILITY_LEVELS, normalize_visibility
 
+# Windows-Konsole ist per Default cp1252 — Unicode-Report (✓, ⚠, →) würde crashen.
+for _stream in (sys.stdout, sys.stderr):
+    try:
+        _stream.reconfigure(encoding="utf-8")
+    except (AttributeError, ValueError):
+        pass
+
 SCRIPT_ROOT = Path(__file__).parent
 VAULT_ROOT = Path(os.environ.get("VAULT_ROOT", str(SCRIPT_ROOT)))
 


### PR DESCRIPTION
## Worum geht's

Beim lokalen Durchlauf der neuen Epic-#28-Skripte auf Windows traten Bugs auf, die den Betrieb verhinderten. Dieser PR macht sie real lauffähig und robust gegen abgebrochene Läufe.

## 1 — Unicode-Crash auf Windows-Konsole

`lint-links.py`, `lint-tree.py`, `promote.py`, `reorganise.py` drucken Report-Glyphen (`✗ ○ → ✓ ⚠`), die nicht in cp1252 liegen → `UnicodeEncodeError`, Lauf bricht ab. stdout/stderr werden nun früh auf UTF-8 reconfiguriert (graceful no-op, wo nicht unterstützt).

## 2 — Pfade respektieren VAULT_ROOT nicht

- `clippings-ingest.py` defaultete auf `<repo>/Clippings` statt `$VAULT_ROOT/Clippings` (wohin der Obsidian Web Clipper schreibt).
- `rebuild-index.py` hatte `WIKI_DIR` hart auf `<repo>/wiki` verdrahtet → `FileNotFoundError` beim Schreiben von `index.md` in der Code/Daten-Trennung.

Beide folgen jetzt `$VAULT_ROOT` (Fallback aufs Repo) und akzeptieren `--clippings-dir` / `--wiki-dir`.

## 3 — reorganise: Klassifizierungs-Cache (crash-sicher)

`reorganise.py` klassifizierte erst **alle** Seiten (1278 LLM-Calls) und schrieb dann am Ende — ein Crash davor verbrannte sämtliche Calls. Jetzt:
- Jede LLM-Antwort wird **sofort** nach `<wiki>/../.reorg-cache.json` persistiert (Key = Pfad + Inhalts-Fingerprint).
- Ein Re-Run — oder `Dry-run → Apply` — liest aus dem Cache statt neu zu klassifizieren. Crash kostet keine Calls mehr, Dry-run+Apply verdoppelt die Kosten nicht.
- Inhaltsänderung → automatische Neuklassifizierung. Graceful, `--no-cache` schaltet ab.

## Test

- `test_access` / `test_promote` / `test_reorganise`: grün (inkl. 4 neue Cache-Tests)
- Real verifiziert: `reorganise.py --apply` → 1244 gelabelt, 33 → `.trash`, 1 übersprungen; `rebuild-index.py` regeneriert `index.md` im Vault; `lint-links.py` meldet danach 0 ungültige + nur noch 1 fehlende visibility (vorher 1278).

🤖 Generated with [Claude Code](https://claude.com/claude-code)