### PR TITLE
feat+fix: reorganise-Klassifizierungs-Cache & rebuild-index VAULT_ROOT

### DIFF
--- a/rebuild-index.py
+++ b/rebuild-index.py
@@ -1,13 +1,29 @@
 """
 rebuild-index.py — Regeneriert wiki/index.md aus allen vorhandenen Wiki-Seiten.
 Liest den 'title'-Eintrag aus dem YAML-Frontmatter jeder Seite.
+
+Usage:
+    uv run rebuild-index.py                 # $VAULT_ROOT/wiki (Fallback: Repo-Pfad)
+    uv run rebuild-index.py --wiki-dir PATH
 """
 
+import argparse
+import os
 import re
+import sys
 from pathlib import Path
 from datetime import datetime
 
-WIKI_DIR = Path(__file__).parent / "wiki"
+# Windows-Konsole ist per Default cp1252 — Unicode-Ausgabe würde crashen.
+for _stream in (sys.stdout, sys.stderr):
+    try:
+        _stream.reconfigure(encoding="utf-8")
+    except (AttributeError, ValueError):
+        pass
+
+SCRIPT_ROOT = Path(__file__).parent
+# Wiki liegt im Vault (OneDrive), nicht im Repo — VAULT_ROOT respektieren, Fallback aufs Repo.
+VAULT_ROOT = Path(os.environ.get("VAULT_ROOT", str(SCRIPT_ROOT)))
 
 SECTIONS = [
     ("concepts", "Konzepte"),
@@ -32,7 +48,7 @@ def extract_title(path: Path) -> str:
     return path.stem
 
 
-def build_index() -> str:
+def build_index(wiki_dir: Path) -> str:
     lines = [
         "# Wiki Index\n",
         f"> Zuletzt generiert: {datetime.now().strftime('%Y-%m-%d %H:%M')} — nicht manuell bearbeiten.\n",
@@ -40,7 +56,7 @@ def build_index() -> str:
 
     total = 0
     for folder, label in SECTIONS:
-        section_dir = WIKI_DIR / folder
+        section_dir = wiki_dir / folder
         if not section_dir.exists():
             continue
 
@@ -60,13 +76,23 @@ def build_index() -> str:
 
 
 def main():
-    print("Lese Wiki-Seiten...")
-    content = build_index()
+    parser = argparse.ArgumentParser(description="Regeneriert wiki/index.md aus dem Frontmatter")
+    parser.add_argument("--wiki-dir", help="Wiki-Verzeichnis (Default: $VAULT_ROOT/wiki)")
+    args = parser.parse_args()
 
-    index_path = WIKI_DIR / "index.md"
+    wiki_dir = Path(args.wiki_dir) if args.wiki_dir else VAULT_ROOT / "wiki"
+    if not wiki_dir.is_dir():
+        print(f"ERROR: Wiki-Verzeichnis nicht gefunden: {wiki_dir}", file=sys.stderr)
+        return 2
+
+    print(f"Lese Wiki-Seiten aus {wiki_dir} ...")
+    content = build_index(wiki_dir)
+
+    index_path = wiki_dir / "index.md"
     index_path.write_text(content, encoding="utf-8")
     print(f"index.md neu geschrieben: {index_path}")
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/reorganise.py
+++ b/reorganise.py
@@ -18,13 +18,18 @@ Sicher per Default:
   - **Graceful** (OKF „tolerate, don't reject"): eine fehlerhafte Einzelseite bricht den Lauf
     nie ab — Seite überspringen, warnen, weitermachen.
   - **Bestehende gültige Labels werden respektiert** (kein Override) außer mit `--reclassify`.
+  - **Klassifizierungs-Cache**: jede LLM-Antwort wird sofort nach `<wiki>/../.reorg-cache.json`
+    persistiert (Key = Pfad + Inhalts-Fingerprint). Ein Crash verbrennt die teuren Calls daher
+    nie — ein Re-Run (oder Dry-run → Apply) liest aus dem Cache statt erneut zu klassifizieren.
+    Bei Inhaltsänderung wird die Seite automatisch neu klassifiziert. `--no-cache` schaltet ab.
 
 Usage:
-    uv run reorganise.py                       # Dry-run über $VAULT_ROOT/wiki
+    uv run reorganise.py                       # Dry-run über $VAULT_ROOT/wiki (füllt den Cache)
     uv run reorganise.py --wiki-dir PATH       # abweichendes Wiki-Verzeichnis
     uv run reorganise.py --apply               # Labels schreiben + personal → .trash verschieben
     uv run reorganise.py --reclassify --apply  # auch bereits gelabelte Seiten neu einstufen
     uv run reorganise.py --limit 5             # nur die ersten 5 Seiten (zum Antesten)
+    uv run reorganise.py --no-cache            # Cache ignorieren, immer frisch klassifizieren
 
 Benötigt in .env (wie ingest.py):
     AZURE_OPENAI_API_KEY=...
@@ -35,6 +40,8 @@ Benötigt in .env (wie ingest.py):
 from __future__ import annotations
 
 import argparse
+import hashlib
+import json
 import os
 import re
 import sys
@@ -156,6 +163,38 @@ def prepend_log(existing: str, entry: str) -> str:
     return "".join(lines[:insert_at]) + entry + "\n" + "".join(lines[insert_at:])
 
 
+def content_fingerprint(text: str) -> str:
+    """Stabiler Hash des Seiteninhalts — ändert sich, sobald die Seite editiert wird."""
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def load_cache(path: Path) -> dict:
+    """Klassifizierungs-Cache laden (rel → {fingerprint, visibility, confidence, reason}).
+
+    Graceful: ein defekter/fehlender Cache liefert leer, bricht den Lauf nie ab.
+    """
+    if path.exists():
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            if isinstance(data, dict):
+                return data
+        except (OSError, json.JSONDecodeError):
+            pass
+    return {}
+
+
+def save_cache(path: Path, cache: dict) -> None:
+    """Cache atomar schreiben (tmp + replace). Der Cache ist Optimierung, kein Pflichtzustand —
+    ein Schreibfehler ist nie fatal."""
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(".tmp")
+        tmp.write_text(json.dumps(cache, ensure_ascii=False, sort_keys=True), encoding="utf-8")
+        tmp.replace(path)
+    except OSError:
+        pass
+
+
 # ---------------------------------------------------------------------------
 # LLM-Klassifizierung (deferred imports — Modul bleibt ohne openai/pydantic importierbar)
 # ---------------------------------------------------------------------------
@@ -248,6 +287,10 @@ def main() -> int:
                         help="auch Seiten mit bereits gültigem visibility-Label neu einstufen")
     parser.add_argument("--limit", type=int, default=0,
                         help="nur die ersten N Seiten verarbeiten (0 = alle)")
+    parser.add_argument("--cache-file",
+                        help="Klassifizierungs-Cache (Default: <wiki>/../.reorg-cache.json)")
+    parser.add_argument("--no-cache", action="store_true",
+                        help="Cache ignorieren und nicht schreiben (immer frisch klassifizieren)")
     args = parser.parse_args()
 
     wiki_dir = Path(args.wiki_dir) if args.wiki_dir else VAULT_ROOT / "wiki"
@@ -273,6 +316,13 @@ def main() -> int:
     today = datetime.now().strftime("%Y-%m-%d")
     trash_dir = wiki_dir / TRASH_DIRNAME
 
+    # Klassifizierungs-Cache: je LLM-Call sofort persistiert, damit ein Crash nie die
+    # teuren Calls verbrennt. Ein Re-Run (oder Dry-run → Apply) liest daraus statt erneut
+    # das LLM zu fragen. Key = rel-Pfad, gültig solange der Inhalts-Fingerprint passt.
+    cache_path = Path(args.cache_file) if args.cache_file else wiki_dir.parent / ".reorg-cache.json"
+    cache = {} if args.no_cache else load_cache(cache_path)
+    cache_hits = 0
+
     plan: list[tuple[str, str, str, str, str]] = []  # (rel, action, visibility, prev, note)
     to_trash: list[tuple[Path, str, str]] = []       # (page, visibility, reason)
     to_label: list[tuple[Path, str]] = []            # (page, visibility)
@@ -297,13 +347,26 @@ def main() -> int:
         if prev_valid and not args.reclassify:
             visibility, note = prev, "vorhandenes Label"
         else:
-            try:
-                visibility, confidence, reason = classify_page(client, deployment, rel, text)
-                note = f"LLM/{confidence}: {reason}"
-            except Exception as exc:  # graceful: eine Seite darf den Lauf nicht abbrechen
-                skipped += 1
-                print(f"  ! SKIP {rel} — Klassifizierung fehlgeschlagen: {exc}", file=sys.stderr)
-                continue
+            fp = content_fingerprint(text)
+            cached = None if args.no_cache else cache.get(rel)
+            if (cached and cached.get("fingerprint") == fp
+                    and cached.get("visibility") in VISIBILITY_LEVELS):
+                visibility = cached["visibility"]
+                note = f"Cache/{cached.get('confidence', '?')}: {cached.get('reason', '')}"
+                cache_hits += 1
+            else:
+                try:
+                    visibility, confidence, reason = classify_page(client, deployment, rel, text)
+                    note = f"LLM/{confidence}: {reason}"
+                except Exception as exc:  # graceful: eine Seite darf den Lauf nicht abbrechen
+                    skipped += 1
+                    print(f"  ! SKIP {rel} — Klassifizierung fehlgeschlagen: {exc}", file=sys.stderr)
+                    continue
+                if not args.no_cache:
+                    # Sofort persistieren: ein späterer Crash verbrennt diesen Call nicht mehr.
+                    cache[rel] = {"fingerprint": fp, "visibility": visibility,
+                                  "confidence": confidence, "reason": reason}
+                    save_cache(cache_path, cache)
 
         if is_private(visibility):
             plan.append((rel, "TRASH", "personal", prev or "—", note))
@@ -326,6 +389,8 @@ def main() -> int:
     print(f"  → .trash (personal)  : {len(to_trash)}")
     print(f"  unverändert          : {sum(1 for p in plan if p[1] == 'keep')}")
     print(f"  übersprungen         : {skipped}")
+    if not args.no_cache:
+        print(f"  aus Cache (kein LLM) : {cache_hits}  →  {cache_path}")
 
     if not args.apply:
         print("\n(Dry-run — mit --apply ausführen, um Labels zu schreiben und personal-Seiten "

--- a/test_reorganise.py
+++ b/test_reorganise.py
@@ -9,11 +9,14 @@ import unittest
 from pathlib import Path
 
 from reorganise import (
+    content_fingerprint,
     current_visibility,
     has_frontmatter,
     is_private,
     iter_curated_pages,
+    load_cache,
     prepend_log,
+    save_cache,
     set_visibility,
     trash_destination,
 )
@@ -133,6 +136,30 @@ class LogTests(unittest.TestCase):
         out = prepend_log("", "## 2026-06-17 — REORGANISE\nneu")
         self.assertIn("# Aktivitätslog", out)
         self.assertIn("REORGANISE", out)
+
+
+class CacheTests(unittest.TestCase):
+    def test_fingerprint_changes_with_content(self):
+        self.assertEqual(content_fingerprint("abc"), content_fingerprint("abc"))
+        self.assertNotEqual(content_fingerprint("abc"), content_fingerprint("abd"))
+
+    def test_save_then_load_roundtrip(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = Path(d) / ".reorg-cache.json"
+            cache = {"concepts/a.md": {"fingerprint": "x", "visibility": "internal",
+                                       "confidence": "high", "reason": "ä → ü"}}
+            save_cache(path, cache)
+            self.assertEqual(load_cache(path), cache)
+
+    def test_missing_cache_is_empty(self):
+        with tempfile.TemporaryDirectory() as d:
+            self.assertEqual(load_cache(Path(d) / "nope.json"), {})
+
+    def test_broken_cache_is_graceful(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = Path(d) / "broken.json"
+            path.write_text("{ not valid json", encoding="utf-8")
+            self.assertEqual(load_cache(path), {})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Kontext

Diese beiden Commits waren ursprünglich auf dem Branch von #40, wurden aber **nach** dessen Merge gepusht und sind daher nie auf `main` gelandet. Dieser PR holt sie nach.

## 1 — reorganise: Klassifizierungs-Cache (crash-sicher)

`reorganise.py` klassifizierte erst **alle** Seiten (1278 LLM-Calls) und schrieb dann am Ende — ein Crash davor verbrannte sämtliche Calls.
- Jede LLM-Antwort wird **sofort** nach `<wiki>/../.reorg-cache.json` persistiert (Key = Pfad + Inhalts-Fingerprint).
- Ein Re-Run — oder `Dry-run → Apply` — liest aus dem Cache statt neu zu klassifizieren. Crash kostet keine Calls mehr, Dry-run+Apply verdoppelt die Kosten nicht.
- Inhaltsänderung → automatische Neuklassifizierung. Graceful (defekter Cache → leer), `--no-cache` schaltet ab.
- +4 Cache-Unit-Tests.

## 2 — rebuild-index: VAULT_ROOT respektieren

`WIKI_DIR` war hart auf `<repo>/wiki` verdrahtet → `FileNotFoundError` in der Code/Daten-Trennung (Wiki liegt im OneDrive-Vault). Folgt jetzt `$VAULT_ROOT/wiki` (Fallback aufs Repo), akzeptiert `--wiki-dir`, plus UTF-8-Konsole.

## Test

- `test_reorganise`: 18 grün (inkl. 4 neue Cache-Tests)
- Real verifiziert: `rebuild-index.py` regeneriert `index.md` im Vault.

🤖 Generated with [Claude Code](https://claude.com/claude-code)