### PR TITLE
fix(wiki-sync): UTF-8-Konsole — WikiSync-Task schlug jeden Lauf fehl

### DIFF
--- a/wiki-sync.py
+++ b/wiki-sync.py
@@ -30,6 +30,14 @@ import tempfile
 from pathlib import Path
 from datetime import datetime, timezone
 
+# Windows-Konsole ist per Default cp1252 — Ausgabe mit → würde crashen (und der
+# Scheduled Task WikiSync damit jeden Lauf fehlschlagen, sobald es etwas zu syncen gibt).
+for _stream in (sys.stdout, sys.stderr):
+    try:
+        _stream.reconfigure(encoding="utf-8")
+    except (AttributeError, ValueError):
+        pass
+
 try:
     from dotenv import load_dotenv
     # Order: OS env > Vault .env (kanonisch, OneDrive-synced) > Script-local .env (Fallback)


### PR DESCRIPTION
## Befund

Beim Durchsehen der Scheduled-Task-Ergebnisse fiel auf: **`KnowledgeTree-WikiSync` lieferte dauerhaft `0x1`** (Fehlschlag).

Ursache: `wiki-sync.py` druckt beim Push `→` (U+2192), das nicht in cp1252 (Default-Windows-Codepage) liegt. Sobald es Dateien zu syncen gab, crashte der Lauf:

```
File "wiki-sync.py", line 162, in sync
    print(f"  {prefix}→ {archive_path}")
UnicodeEncodeError: 'charmap' codec can't encode character '→'
```

Konsequenz: Der **Wiki→GitHub-Archiv-Backup lief faktisch nicht** (jeder 2-Stunden-Lauf brach ab). `--pull` (WikiPull) war nicht betroffen, weil der Pfad mit `→` nur im Push-Zweig liegt.

## Fix

stdout/stderr früh auf UTF-8 reconfigurieren — gleiche Bug-Klasse und gleiche Lösung wie bei `lint-links` / `lint-tree` / `promote` / `reorganise` (#40/#42).

## Test

`uv run wiki-sync.py --dry-run` läuft jetzt sauber durch (81 Dateien würden gesynct, vorher Crash). Ein vollständiger Scan aller `*.py` zeigt: dies war das letzte Skript mit cp1252-unsicherer Ausgabe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)