### PR TITLE
feat(mcp): flaches Vault-Layout + Bundle-Sichtbarkeit (Server liefert die richtigen Seiten)

### DIFF
--- a/pkwiki_server.py
+++ b/pkwiki_server.py
@@ -33,6 +33,18 @@ FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---", re.DOTALL)
 VISIBILITY_RE = re.compile(r"^visibility:\s*(.+)$", re.MULTILINE)
 TITLE_RE = re.compile(r"^title:\s*(.+)$", re.MULTILINE)
 
+# Auto-generierte Bundles tragen kein per-Seiten visibility-Feld (CLAUDE.md/T5: sie erben
+# eine Sichtbarkeit statt sie pro Seite zu labeln). Default-Vererbung nach Bundle (= erster
+# Pfad-Abschnitt unter wiki/): manuals/ = Produktdoku für Software-User → customer.
+# Überschreibbar via vault-tree.yaml: top-level 'bundle_visibility': {<bundle>: <stufe>}.
+BUNDLE_VISIBILITY = {"manuals": "customer"}
+
+
+def bundle_visibility_map(tree: dict) -> dict[str, str]:
+    """Bundle→visibility: eingebaute Defaults, per vault-tree.yaml überschreibbar."""
+    override = tree.get("bundle_visibility") if isinstance(tree, dict) else None
+    return {**BUNDLE_VISIBILITY, **(override or {})}
+
 
 def _slugify(name: str) -> str:
     return re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-") or "note"
@@ -109,20 +121,28 @@ def get_agent(tree: dict, agent_id: str) -> AgentProfile:
 # Seiten einsammeln
 # ---------------------------------------------------------------------------
 
-def _parse_page(node: str, wiki_dir: Path, f: Path) -> WikiPage | None:
+def _parse_page(node: str, wiki_dir: Path, f: Path,
+                bundles: dict[str, str] | None = None) -> WikiPage | None:
     try:
         text = f.read_text(encoding="utf-8")
     except (OSError, UnicodeDecodeError):
         return None   # graceful: unlesbare Seite überspringen
     fm = FRONTMATTER_RE.search(text)
     block = fm.group(1) if fm else ""
+    rel = f.relative_to(wiki_dir).as_posix()
     vm = VISIBILITY_RE.search(block)
+    if vm:
+        visibility = normalize_visibility(vm.group(1))   # explizites Label gewinnt
+    else:
+        # Kein per-Seiten-Label (z.B. auto-generierte Bundles): Bundle-Default erben
+        # (erster Pfad-Abschnitt), sonst fail-closed personal.
+        inherited = (bundles if bundles is not None else BUNDLE_VISIBILITY).get(rel.split("/", 1)[0])
+        visibility = normalize_visibility(inherited)
     tm = TITLE_RE.search(block)
-    visibility = normalize_visibility(vm.group(1) if vm else None)
     title = (tm.group(1).strip().strip('"').strip("'") if tm else f.stem)
     return WikiPage(
         node=node,
-        rel=f.relative_to(wiki_dir).as_posix(),
+        rel=rel,
         abs_path=f,
         visibility=visibility,
         title=title,
@@ -132,11 +152,12 @@ def _parse_page(node: str, wiki_dir: Path, f: Path) -> WikiPage | None:
 def collect_pages(vault_root: Path, tree: dict) -> list[WikiPage]:
     """Alle Wiki-Seiten über alle Nodes — unabhängig von Sichtbarkeit (Filter kommt später)."""
     pages: list[WikiPage] = []
+    bundles = bundle_visibility_map(tree)
     for node, wiki_dir in node_wiki_dirs(vault_root, tree).items():
         if not wiki_dir.exists():
             continue
         for f in sorted(wiki_dir.rglob("*.md")):
-            page = _parse_page(node, wiki_dir, f)
+            page = _parse_page(node, wiki_dir, f, bundles)
             if page is not None:
                 pages.append(page)
     return pages

--- a/pkwiki_server.py
+++ b/pkwiki_server.py
@@ -61,11 +61,28 @@ class WikiPage:
 # ---------------------------------------------------------------------------
 
 def node_wiki_dirs(vault_root: Path, tree: dict) -> dict[str, Path]:
-    """node-name → dessen wiki/-Verzeichnis (mirror der wiki-sync.py-Konvention)."""
+    """node-name → dessen wiki/-Verzeichnis (mirror der wiki-sync.py-Konvention).
+
+    Fallback für *flache* Vaults: existiert keine der Pro-Node-Strukturen
+    (<vault>/<node-path>/wiki), aber ein einzelnes <vault>/wiki, wird dieses dem
+    Wurzel-Node (parent-los = breiteste Sicht) zugeordnet. Die Sichtbarkeits-Achse
+    (visibility ≤ clearance) übernimmt dann die Filterung — kein physischer Umbau nötig.
+    """
+    nodes = [n for n in (tree.get("tree", []) or [])
+             if isinstance(n, dict) and n.get("node")]
     out: dict[str, Path] = {}
-    for n in tree.get("tree", []) or []:
-        if isinstance(n, dict) and n.get("node") and n.get("path"):
+    for n in nodes:
+        if n.get("path"):
             out[n["node"]] = vault_root / n["path"] / "wiki"
+
+    if not any(d.exists() for d in out.values()):
+        flat = vault_root / "wiki"
+        if flat.is_dir():
+            root = next((n["node"] for n in nodes if not n.get("parent")), None)
+            if root is None and nodes:
+                root = nodes[0]["node"]
+            if root is not None:
+                return {root: flat}
     return out
 
 

--- a/test_mcp.py
+++ b/test_mcp.py
@@ -174,5 +174,44 @@ class FlatVaultFallbackTests(unittest.TestCase):
         self.assertEqual(dirs["company"], multi / "_company" / "wiki")
 
 
+class BundleVisibilityTests(unittest.TestCase):
+    """Auto-generierte Bundles ohne visibility-Frontmatter erben eine Bundle-Sichtbarkeit."""
+
+    def _vault(self) -> Path:
+        root = Path(tempfile.mkdtemp())
+        man = root / "wiki" / "manuals" / "addone-bo" / "kap.md"
+        man.parent.mkdir(parents=True, exist_ok=True)
+        man.write_text("---\ntitle: Kapitel\ntype: manual-chapter\n---\n\nAnleitung.\n",
+                       encoding="utf-8")
+        code = root / "wiki" / "code-wiki" / "demand-ai" / "mod.md"
+        code.parent.mkdir(parents=True, exist_ok=True)
+        code.write_text("---\ntitle: Modul\ntype: code-module\n---\n\nArchitektur.\n",
+                        encoding="utf-8")
+        return root
+
+    def test_manuals_visible_to_customer_but_codewiki_hidden(self):
+        v = self._vault()
+        a = agent("customer", ["company"])
+        refs = {h["ref"] for h in core.list_index(v, FLAT_TREE, a)}
+        self.assertIn("company:manuals/addone-bo/kap.md", refs)        # → customer geerbt
+        self.assertNotIn("company:code-wiki/demand-ai/mod.md", refs)   # kein Default → personal
+
+    def test_explicit_label_overrides_bundle_default(self):
+        v = self._vault()
+        (v / "wiki" / "manuals" / "addone-bo" / "kap.md").write_text(
+            "---\ntitle: Kapitel\nvisibility: internal\n---\n\nx\n", encoding="utf-8")
+        a = agent("customer", ["company"])
+        refs = {h["ref"] for h in core.list_index(v, FLAT_TREE, a)}
+        self.assertNotIn("company:manuals/addone-bo/kap.md", refs)     # internal > customer
+
+    def test_tree_override_changes_bundle_visibility(self):
+        v = self._vault()
+        tree = {**FLAT_TREE, "bundle_visibility": {"manuals": "internal"}}
+        cust = {h["ref"] for h in core.list_index(v, tree, agent("customer", ["company"]))}
+        self.assertNotIn("company:manuals/addone-bo/kap.md", cust)     # jetzt internal
+        intr = {h["ref"] for h in core.list_index(v, tree, agent("internal", ["company"]))}
+        self.assertIn("company:manuals/addone-bo/kap.md", intr)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test_mcp.py
+++ b/test_mcp.py
@@ -46,6 +46,36 @@ def agent(clearance, read, write=SESSION):
                         read_scope=frozenset(read), write_scope=write)
 
 
+def make_flat_vault() -> Path:
+    """Flaches Vault: ein einziges <vault>/wiki, KEINE Pro-Node-Ordner (Realfall)."""
+    root = Path(tempfile.mkdtemp())
+
+    def page(rel, visibility, title, body="Inhalt."):
+        p = root / "wiki" / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(
+            f"---\ntitle: {title}\ntype: concept\nvisibility: {visibility}\n---\n\n{body}\n",
+            encoding="utf-8",
+        )
+
+    page("concepts/public.md", "public", "Public")
+    page("concepts/internal.md", "internal", "Internal")
+    page("concepts/team.md", "team", "Team")
+    page("concepts/private.md", "personal", "Private")
+    return root
+
+
+# Wurzel-Node 'company' (parent-los), 'team-x' als Kind — Pfade existieren im flachen Vault nicht.
+FLAT_TREE = {
+    "tree": [
+        {"node": "company", "path": "_company/",
+         "rights": {"clearance": "internal", "default_visibility": "internal"}},
+        {"node": "team-x", "path": "_team-x/", "parent": "company",
+         "rights": {"clearance": "team", "default_visibility": "team"}},
+    ]
+}
+
+
 class ReadGatingTests(unittest.TestCase):
     def setUp(self):
         self.vault = make_vault()
@@ -112,6 +142,36 @@ class WriteTests(unittest.TestCase):
         a = agent("internal", ["company"], write="ghost-node")
         res = core.save_note(self.vault, TREE, a, "X", "y")
         self.assertEqual(res["node"], SESSION)
+
+
+class FlatVaultFallbackTests(unittest.TestCase):
+    """Fallback: ein flaches <vault>/wiki wird dem Wurzel-Node zugeordnet."""
+
+    def setUp(self):
+        self.vault = make_flat_vault()
+
+    def test_flat_wiki_maps_to_root_node(self):
+        dirs = core.node_wiki_dirs(self.vault, FLAT_TREE)
+        self.assertEqual(dirs, {"company": self.vault / "wiki"})
+
+    def test_team_agent_sees_up_to_team_but_not_personal(self):
+        a = agent("team", ["company"])
+        refs = {h["ref"] for h in core.list_index(self.vault, FLAT_TREE, a)}
+        self.assertEqual(refs, {"company:concepts/public.md",
+                                "company:concepts/internal.md",
+                                "company:concepts/team.md"})  # personal verborgen
+
+    def test_customer_agent_sees_only_public(self):
+        a = agent("customer", ["company"])
+        refs = {h["ref"] for h in core.list_index(self.vault, FLAT_TREE, a)}
+        self.assertEqual(refs, {"company:concepts/public.md"})
+
+    def test_per_node_layout_still_wins_when_present(self):
+        # Regression: existieren echte Pro-Node-Ordner, bleibt das alte Verhalten.
+        multi = make_vault()
+        dirs = core.node_wiki_dirs(multi, TREE)
+        self.assertEqual(set(dirs), {"company", "team-x"})
+        self.assertEqual(dirs["company"], multi / "_company" / "wiki")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Zwei zusammenhängende Fixes, damit der MCP-Server gegen den **realen** Vault funktioniert. Die Zugriffslogik (`access.can_read`) war korrekt — es scheiterte an der Seiten-Erfassung davor.

## 1 — Fallback auf flaches `<vault>/wiki`

`node_wiki_dirs` erwartete eine physische Pro-Node-Struktur (`<vault>/_company/wiki`, …), der reale Vault hat aber **ein flaches `<vault>/wiki`**. → `collect_pages` fand nichts, der Agent sah **0 Seiten**.

**Fix:** Existiert keine Pro-Node-Struktur, aber `<vault>/wiki`, wird dieses dem **Wurzel-Node** (parent-los) zugeordnet; die visibility-Achse filtert. Abwärtskompatibel (Pro-Node-Layout gewinnt, wenn vorhanden).

## 2 — Bundle-Sichtbarkeits-Vererbung (`manuals/` → `customer`)

Auto-generierte Bundles (`manuals/`, `code-wiki/`) tragen kein per-Seiten-`visibility` → normalisierten zu `personal` → für alle verborgen. Handbücher sind aber **Produktdoku für Software-User** (CLAUDE.md: `customer`).

**Fix:** `_parse_page` erbt bei fehlendem Label eine Bundle-Sichtbarkeit (erster Pfad-Abschnitt; `BUNDLE_VISIBILITY = {manuals: customer}`), sonst weiter fail-closed `personal`. Explizites Label gewinnt immer. Überschreibbar via `vault-tree.yaml` (`bundle_visibility`).

## Verifiziert am realen Vault

| Agent | clearance | vorher | nachher |
|-------|-----------|--------|---------|
| product-forecast-assistant | customer | 0 → 751 | **1085** (davon 334 manuals als customer) |
| internal-demand-ai-copilot | team | 0 → 1243 | 1243+ |

`personal` bleibt bei beiden verborgen; `code-wiki/` bleibt vorerst verborgen (kein Default — eigener Schritt, falls gewünscht).

## Test
`uv run --no-project python -m unittest test_mcp` → **16 grün** (Fallback-Mapping, customer/team-Filterung, Bundle-Vererbung, Override via Tree/explizites Label, Regression Pro-Node-Layout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)