### PR TITLE
feat(mcp): persönliches Langzeitgedächtnis — persistenter personal-Node (lesen + schreiben)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ output/*
 
 # Ephemerer MCP-Session-Sandbox (write_scope: session) — nie committen
 .sessions/
+
+# MCP-Client-Registrierung — maschinen-spezifisch (VAULT_ROOT-Pfad, Agenten-ID)
+.mcp.json

--- a/pkwiki_server.py
+++ b/pkwiki_server.py
@@ -72,29 +72,37 @@ class WikiPage:
 # Konfiguration / Baum
 # ---------------------------------------------------------------------------
 
-def node_wiki_dirs(vault_root: Path, tree: dict) -> dict[str, Path]:
-    """node-name → dessen wiki/-Verzeichnis (mirror der wiki-sync.py-Konvention).
+def _root_node(nodes: list[dict]) -> str | None:
+    """Wurzel-Node (parent-los = breiteste Sicht); Fallback: erster Node."""
+    root = next((n["node"] for n in nodes if not n.get("parent")), None)
+    if root is None and nodes:
+        root = nodes[0]["node"]
+    return root
 
-    Fallback für *flache* Vaults: existiert keine der Pro-Node-Strukturen
-    (<vault>/<node-path>/wiki), aber ein einzelnes <vault>/wiki, wird dieses dem
-    Wurzel-Node (parent-los = breiteste Sicht) zugeordnet. Die Sichtbarkeits-Achse
-    (visibility ≤ clearance) übernimmt dann die Filterung — kein physischer Umbau nötig.
+
+def node_wiki_dirs(vault_root: Path, tree: dict) -> dict[str, Path]:
+    """node-name → dessen wiki/-Verzeichnis für das LESEN (Seiten-Erfassung).
+
+    Erfasst alle existierenden Pro-Node-Ordner (<vault>/<node-path>/wiki) UND — koexistierend —
+    ein flaches <vault>/wiki, das dem Wurzel-Node zugeordnet wird, sofern es nicht ohnehin
+    schon einem Node gehört. So funktionieren beide Layouts zugleich: die geteilte flache
+    Wiki (= Wurzel-Node) und z.B. ein persönlicher Node mit eigenem Verzeichnis. Die
+    Sichtbarkeits-Achse (visibility ≤ clearance) übernimmt die Filterung.
     """
     nodes = [n for n in (tree.get("tree", []) or [])
              if isinstance(n, dict) and n.get("node")]
     out: dict[str, Path] = {}
     for n in nodes:
         if n.get("path"):
-            out[n["node"]] = vault_root / n["path"] / "wiki"
+            d = vault_root / n["path"] / "wiki"
+            if d.exists():
+                out[n["node"]] = d
 
-    if not any(d.exists() for d in out.values()):
-        flat = vault_root / "wiki"
-        if flat.is_dir():
-            root = next((n["node"] for n in nodes if not n.get("parent")), None)
-            if root is None and nodes:
-                root = nodes[0]["node"]
-            if root is not None:
-                return {root: flat}
+    flat = vault_root / "wiki"
+    if flat.is_dir() and flat not in out.values():
+        root = _root_node(nodes)
+        if root is not None and root not in out:
+            out[root] = flat
     return out
 
 
@@ -231,16 +239,34 @@ def list_index(vault_root: Path, tree: dict, agent: AgentProfile) -> list[dict]:
 # Schreib-Operationen (nur in write_scope; 'session' = ephemerer Sandbox)
 # ---------------------------------------------------------------------------
 
+def _node_path(tree: dict, node: str) -> str | None:
+    """Deklarierter Pfad eines Nodes aus vault-tree.yaml (für Schreibziele)."""
+    for n in tree.get("tree", []) or []:
+        if isinstance(n, dict) and n.get("node") == node:
+            return n.get("path")
+    return None
+
+
 def _write_target(vault_root: Path, tree: dict, agent: AgentProfile) -> tuple[str, Path, str]:
-    """(node-label, wiki-dir, visibility) für Schreibvorgänge des Agenten."""
+    """(node-label, wiki-dir, visibility) für Schreibvorgänge des Agenten.
+
+    Bevorzugt das LESE-Verzeichnis des write_scope-Nodes (→ Geschriebenes ist auch wieder
+    lesbar). Existiert es noch nicht, wird der deklarierte Node-Pfad genommen und beim
+    Schreiben angelegt (persistenter persönlicher/Team-Node). Nur wenn der Node weder
+    gemappt noch deklariert ist, weicht der Server fail-closed in die Session-Sandbox aus.
+    """
     if agent.write_scope == SESSION:
-        # ephemerer, nicht-synchronisierter Sandbox-Node
         return SESSION, vault_root / ".sessions" / agent.id / "wiki", "personal"
-    wiki_dir = node_wiki_dirs(vault_root, tree).get(agent.write_scope)
-    if wiki_dir is None:
-        # write_scope zeigt auf unbekannten Node → fail closed: in Session ausweichen
+
+    read_dir = node_wiki_dirs(vault_root, tree).get(agent.write_scope)
+    path = _node_path(tree, agent.write_scope)
+    if read_dir is not None:
+        target = read_dir
+    elif path:
+        target = vault_root / path / "wiki"     # wird beim Schreiben angelegt
+    else:
         return SESSION, vault_root / ".sessions" / agent.id / "wiki", "personal"
-    return agent.write_scope, wiki_dir, node_default_visibility(tree, agent.write_scope)
+    return agent.write_scope, target, node_default_visibility(tree, agent.write_scope)
 
 
 def remember(vault_root: Path, tree: dict, agent: AgentProfile, text: str) -> dict:

--- a/test_mcp.py
+++ b/test_mcp.py
@@ -213,5 +213,46 @@ class BundleVisibilityTests(unittest.TestCase):
         self.assertIn("company:manuals/addone-bo/kap.md", intr)
 
 
+PERSONAL_TREE = {
+    "tree": [
+        {"node": "company", "path": "_company/",
+         "rights": {"clearance": "internal", "default_visibility": "internal"}},
+        {"node": "pers", "path": "_pers/", "parent": "company",
+         "rights": {"clearance": "personal", "default_visibility": "personal"}},
+    ]
+}
+
+
+class PersonalMemoryTests(unittest.TestCase):
+    """Persönlicher Agent (clearance=personal) schreibt in seinen Node UND liest zurück,
+    während die geteilte flache Wiki (company) weiter sichtbar bleibt."""
+
+    def setUp(self):
+        self.vault = make_flat_vault()   # flaches <vault>/wiki = company-Node
+
+    def test_writes_to_personal_node_not_session(self):
+        a = agent("personal", ["pers", "company"], write="pers")
+        res = core.save_note(self.vault, PERSONAL_TREE, a, "Mein Merksatz", "Inhalt")
+        self.assertTrue(res["ok"])
+        self.assertEqual(res["node"], "pers")
+        self.assertEqual(res["visibility"], "personal")
+        self.assertNotIn(".sessions", res["path"])
+        self.assertTrue((self.vault / "_pers" / "wiki" / "concepts").exists())
+
+    def test_personal_agent_reads_its_note_back_and_shared_wiki(self):
+        a = agent("personal", ["pers", "company"], write="pers")
+        core.save_note(self.vault, PERSONAL_TREE, a, "Mein Merksatz", "Inhalt")
+        refs = {h["ref"] for h in core.list_index(self.vault, PERSONAL_TREE, a)}
+        self.assertIn("pers:concepts/mein-merksatz.md", refs)   # eigenes zurücklesbar
+        self.assertIn("company:concepts/public.md", refs)       # geteilte Wiki weiter da
+
+    def test_team_agent_cannot_see_personal_note(self):
+        pa = agent("personal", ["pers", "company"], write="pers")
+        core.save_note(self.vault, PERSONAL_TREE, pa, "Geheim", "privat")
+        ta = agent("team", ["company"])   # pers nicht im scope, clearance < personal
+        refs = {h["ref"] for h in core.list_index(self.vault, PERSONAL_TREE, ta)}
+        self.assertNotIn("pers:concepts/geheim.md", refs)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/vault-tree.yaml.example
+++ b/vault-tree.yaml.example
@@ -85,5 +85,14 @@ agents:
     read_scope: [team-demand-ai, company]
     write_scope: team-demand-ai
 
+  # Persönliches Langzeitgedächtnis: schreibt in den eigenen personal-Node UND liest ihn
+  # zurück (clearance 'personal'). Sieht zusätzlich Team + Company nach oben. Privates bleibt
+  # im personal-Node; Hochstufen ins Team/Company nur via promote.py (Review-Gate, T4).
+  - id: personal-christian-copilot
+    description: "Persönlicher Copilot/Gedächtnis für christian"
+    clearance: personal
+    read_scope: [personal-christian, team-demand-ai, company]
+    write_scope: personal-christian
+
 poll_interval_minutes: 15
 last_poll_state: .code-watch-state.json


### PR DESCRIPTION
## Ziel

Der Copilot soll dauerhaft in einen **persönlichen Bereich** schreiben **und** ihn wieder zurücklesen (privates Langzeitgedächtnis) — statt ephemer in die Session-Sandbox oder ins geteilte Company-Wiki.

## Problem

Im flachen Vault kollabierte der Flat-Fallback die Node-Map auf `{root: flat}`. Dadurch hatte ein write_scope wie `personal-christian` **kein** Verzeichnis → `_write_target` fiel auf die **Session-Sandbox** zurück (ephemer). Persistentes Schreiben in einen eigenen Node war nicht möglich.

## Änderungen

- **`node_wiki_dirs` — Koexistenz statt Alles-oder-nichts:** erfasst existierende Pro-Node-Ordner **und** das flache `<vault>/wiki` (= Wurzel-Node) gleichzeitig. Geteilte Wiki und persönlicher Node sind damit zusammen lesbar.
- **`_write_target` — read = write:** schreibt ins Lese-Verzeichnis des write_scope-Nodes (Geschriebenes ist auch wieder lesbar); existiert es noch nicht, wird der deklarierte Node-Pfad beim ersten Schreiben angelegt. Nur ohne Mapping/Pfad weiterhin Session-Fallback.
- **Neues Referenzprofil** `personal-christian-copilot` (clearance `personal`, write_scope `personal-christian`, read_scope `personal+team+company`) in `vault-tree.yaml.example`.
- **`.gitignore`:** maschinen-spezifische `.mcp.json` (MCP-Client-Registrierung) ignorieren.

## Verifiziert am realen Vault

```
Agent: personal-christian-copilot | clearance: personal | write_scope: personal-christian
save_note -> node: personal-christian | visibility: personal
  path: …\_team-demand-ai\_personal-christian\wiki\concepts\…md
read_page zurück lesbar: True
```

`lint-tree.py`: 0 Errors/Warnings. `test_mcp`: **19 grün** (+3: schreibt in personal-Node statt Session, liest eigene Notiz + geteilte Wiki zurück, team-Agent sieht personal-Notiz nicht). Abwärtskompatibel (Pro-Node- und Flat-Layout-Tests bleiben grün).

## Sicherheit (Anschluss an die Rechte-Diskussion)

Identität & Scopes kommen aus `vault-tree.yaml` (außerhalb der Schreibzone des Agenten) und der Launch-Config — der Copilot kann sie nicht selbst ändern. Privates bleibt im `personal`-Node; Hochstufen ins Team/Company nur via `promote.py` (Review-Gate, T4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)